### PR TITLE
Add structured data source and session models

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,7 +1,4 @@
 import os
-import asyncio
-import orjson
-from typing import Any, Dict
 from fastapi import FastAPI, Request, HTTPException
 from pydantic import BaseModel
 from dotenv import load_dotenv
@@ -34,16 +31,19 @@ application: Application = (
 )
 
 # ===== Data Loading =====
-DATA: Dict[str, Any] = {}
-def load_data():
-    import json, pathlib
+from bot.state import DataSource
+
+DATA: DataSource
+
+
+def load_data() -> DataSource:
+    import pathlib
+
     path = pathlib.Path(__file__).parent / "data" / "capitals.json"
     if not path.exists():
         raise RuntimeError("data/capitals.json missing")
-    # orjson for speed; fallback to json if needed
-    with open(path, "rb") as f:
-        content = f.read()
-    return orjson.loads(content)
+    return DataSource.load(path)
+
 
 DATA = load_data()
 

--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -1,6 +1,8 @@
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from app import DATA
+
 async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE):
     q = update.callback_query
     await q.answer()

--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -1,6 +1,8 @@
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from app import DATA
+
 async def cb_coop(update: Update, context: ContextTypes.DEFAULT_TYPE):
     q = update.callback_query
     await q.answer()

--- a/bot/handlers_sprint.py
+++ b/bot/handlers_sprint.py
@@ -1,6 +1,8 @@
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from app import DATA
+
 async def cb_sprint(update: Update, context: ContextTypes.DEFAULT_TYPE):
     q = update.callback_query
     await q.answer()

--- a/bot/questions.py
+++ b/bot/questions.py
@@ -1,24 +1,17 @@
 import random
-from typing import Any, Dict
 
-def pick_question(data: Dict[str, Any], continent: str | None, mode: str):
+from .state import DataSource
+
+
+def pick_question(data: DataSource, continent: str | None, mode: str):
+    """Generate a question based on the provided mode."""
     # mode: "country_to_capital" | "capital_to_country" | "mixed"
-    countries = []
-    if continent and continent in data["countries_by_continent"]:
-        countries = data["countries_by_continent"][continent]
-    else:
-        # объединяем все
-        seen = set()
-        for v in data["countries_by_continent"].values():
-            for c in v:
-                seen.add(c)
-        countries = list(seen)
-
+    countries = data.countries(continent)
     if not countries:
         raise RuntimeError("No countries for selected continent")
 
     country = random.choice(countries)
-    capital = data["capital_by_country"][country]
+    capital = data.capital_by_country[country]
 
     question_type = mode
     if mode == "mixed":
@@ -26,8 +19,7 @@ def pick_question(data: Dict[str, Any], continent: str | None, mode: str):
 
     if question_type == "country_to_capital":
         correct = capital
-        # отвлекающие — другие столицы из пула
-        pool = [data["capital_by_country"][c] for c in countries if c != country]
+        pool = [c for c in data.capitals(continent) if c != capital]
     else:
         correct = country
         pool = [c for c in countries if c != country]
@@ -47,5 +39,5 @@ def pick_question(data: Dict[str, Any], continent: str | None, mode: str):
         "capital": capital,
         "prompt": prompt,
         "correct": correct,
-        "options": options
+        "options": options,
     }

--- a/bot/state.py
+++ b/bot/state.py
@@ -1,0 +1,106 @@
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Set
+import orjson
+
+
+@dataclass
+class DataSource:
+    """In-memory representation of countries and capitals."""
+
+    countries_by_continent: Dict[str, Set[str]]
+    capital_by_country: Dict[str, str]
+    country_by_capital: Dict[str, str]
+    aliases: Dict[str, str]
+
+    @classmethod
+    def load(cls, path: str | Path) -> "DataSource":
+        """Load data from a JSON file."""
+        if isinstance(path, str):
+            path = Path(path)
+        with open(path, "rb") as f:
+            raw = orjson.loads(f.read())
+
+        countries_by_continent = {
+            continent: set(countries)
+            for continent, countries in raw.get("countries_by_continent", {}).items()
+        }
+        capital_by_country = raw.get("capital_by_country", {})
+        country_by_capital = {cap: country for country, cap in capital_by_country.items()}
+        aliases = {k.casefold(): v for k, v in raw.get("aliases", {}).items()}
+        # allow case-insensitive matching for canonical names as well
+        for name in list(capital_by_country.keys()) + list(capital_by_country.values()):
+            aliases.setdefault(name.casefold(), name)
+
+        return cls(
+            countries_by_continent=countries_by_continent,
+            capital_by_country=capital_by_country,
+            country_by_capital=country_by_capital,
+            aliases=aliases,
+        )
+
+    def normalize(self, name: str) -> str:
+        """Normalize an input string using aliases."""
+        return self.aliases.get(name.casefold(), name)
+
+    def countries(self, continent: str | None = None) -> List[str]:
+        if continent and continent in self.countries_by_continent:
+            pool: Iterable[str] = self.countries_by_continent[continent]
+        else:
+            pool = {
+                country for countries in self.countries_by_continent.values() for country in countries
+            }
+        return sorted(pool)
+
+    def capitals(self, continent: str | None = None) -> List[str]:
+        if continent and continent in self.countries_by_continent:
+            countries = self.countries_by_continent[continent]
+            pool = [self.capital_by_country[c] for c in countries]
+        else:
+            pool = self.capital_by_country.values()
+        return sorted(pool)
+
+    def items(self, continent: str | None, mode: str) -> List[str]:
+        """Return a list of countries or capitals based on mode."""
+        if mode == "country_to_capital":
+            return self.countries(continent)
+        if mode == "capital_to_country":
+            return self.capitals(continent)
+        # mixed
+        return self.countries(continent) + self.capitals(continent)
+
+
+@dataclass
+class CardSession:
+    user_id: int
+    continent_filter: str | None = None
+    mode: str = "mixed"
+    queue: List[str] = field(default_factory=list)
+    unknown_set: Set[str] = field(default_factory=set)
+    stats: Dict[str, int] = field(default_factory=lambda: {"shown": 0, "known": 0})
+
+
+@dataclass
+class SprintSession:
+    user_id: int
+    duration_sec: int = 60
+    start_ts: float | None = None
+    score: int = 0
+    questions_asked: int = 0
+
+
+@dataclass
+class CoopSession:
+    chat_id: int
+    players: List[int] = field(default_factory=list)
+    continent_filter: str | None = None
+    mode: str = "mixed"
+    difficulty: str = "easy"
+    total_rounds: int = 10
+    current_round: int = 0
+    turn: int = 0
+    team_score: int = 0
+    bot_score: int = 0
+    jobs: Dict[str, Any] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- implement DataSource with loading, normalization and filtering helpers
- add dataclasses for CardSession, SprintSession and CoopSession
- replace raw JSON data with DataSource instance and expose it to handlers
- update question generator and handlers to use DataSource

## Testing
- `python -m py_compile app.py bot/state.py bot/handlers_cards.py bot/handlers_sprint.py bot/handlers_coop.py bot/questions.py`


------
https://chatgpt.com/codex/tasks/task_e_68c1f8eb7f78832696509989bfdf0316