### PR TITLE
Add menu keyboards for continent and direction selection

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -1,9 +1,28 @@
+"""Placeholder handler for the flash cards game."""
+
 from telegram import Update
 from telegram.ext import ContextTypes
 
 from app import DATA
 
-async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE):
+
+async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle ``^cards:`` callbacks.
+
+    Expected callback data: ``cards:<continent>:<direction>``.
+    The selections are stored in ``user_data`` for future use.
+    """
+
     q = update.callback_query
     await q.answer()
-    await q.edit_message_text("Карточки: здесь будет выбор континента/режима и показ карточек.")
+    try:
+        _, continent, direction = q.data.split(":", 2)
+    except ValueError:  # pragma: no cover - defensive
+        continent = direction = ""
+
+    context.user_data["continent"] = continent
+    context.user_data["direction"] = direction
+
+    await q.edit_message_text(
+        f"Карточки: континент {continent or '—'}, режим {direction or '—'}."
+    )

--- a/bot/handlers_menu.py
+++ b/bot/handlers_menu.py
@@ -1,6 +1,9 @@
+"""Handlers for the main menu flow."""
+
 from telegram import Update
 from telegram.ext import ContextTypes
-from .keyboards import main_menu_kb
+
+from .keyboards import main_menu_kb, continent_kb, direction_kb
 
 WELCOME = (
     "Привет! Это бот для тренировки знаний столицы ↔ страна.\n"
@@ -12,29 +15,29 @@ async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await context.bot.send_message(chat_id, WELCOME, reply_markup=main_menu_kb())
 
 async def cb_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    """Handle all ``^menu:`` callbacks."""
+
     q = update.callback_query
     await q.answer()
     data = q.data
 
-    if data == "menu:cards":
-        # открыть подменю карточек
-        await q.edit_message_text(
-            "📘 Флэш-карточки: выбери континент и тип вопросов.",
-            reply_markup=None
-        )
-        # маршрут к cards:
-        await context.bot.send_message(q.message.chat_id, "Старт карточек (заглушка).")
-        # Реально: отправить инлайн-кнопки выбора параметров и вызвать cards flow
+    if data in {"menu:cards", "menu:sprint"}:
+        mode = data.split(":")[1]
+        text = "📘 Флэш-карточки: выбери континент." if mode == "cards" else "⏱ Игра на время: выбери континент."
+        await q.edit_message_text(text, reply_markup=continent_kb(f"menu:{mode}"))
 
-    elif data == "menu:sprint":
+    elif data.startswith("menu:cards:") or data.startswith("menu:sprint:"):
+        parts = data.split(":", 2)
+        mode = parts[1]
+        continent = parts[2]
+        context.user_data["continent"] = continent
         await q.edit_message_text(
-            "⏱ Игра на время: длительность 60 сек. Вопросы в обе стороны.",
-            reply_markup=None
+            "Выбери направление вопросов:",
+            reply_markup=direction_kb(mode, continent),
         )
-        await context.bot.send_message(q.message.chat_id, "Старт спринта (заглушка).")
 
     elif data == "menu:coop":
         await q.edit_message_text(
             "🤝 Дуэт против Бота: запускай в групповом чате командой /coop_capitals",
-            reply_markup=None
+            reply_markup=None,
         )

--- a/bot/handlers_sprint.py
+++ b/bot/handlers_sprint.py
@@ -1,9 +1,28 @@
+"""Placeholder handler for the sprint game."""
+
 from telegram import Update
 from telegram.ext import ContextTypes
 
 from app import DATA
 
-async def cb_sprint(update: Update, context: ContextTypes.DEFAULT_TYPE):
+
+async def cb_sprint(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle ``^sprint:`` callbacks.
+
+    Expected callback data: ``sprint:<continent>:<direction>`` where ``direction``
+    corresponds to question direction. Selections are stored in ``user_data``.
+    """
+
     q = update.callback_query
     await q.answer()
-    await q.edit_message_text("Спринт: здесь будет 60-секундная серия вопросов с кнопками.")
+    try:
+        _, continent, direction = q.data.split(":", 2)
+    except ValueError:  # pragma: no cover - defensive
+        continent = direction = ""
+
+    context.user_data["continent"] = continent
+    context.user_data["direction"] = direction
+
+    await q.edit_message_text(
+        f"Спринт: континент {continent or '—'}, режим {direction or '—'}."
+    )

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -1,9 +1,66 @@
+"""Inline keyboards used across the bot menus."""
+
 from telegram import InlineKeyboardMarkup, InlineKeyboardButton
 
-def main_menu_kb():
+
+def main_menu_kb() -> InlineKeyboardMarkup:
+    """Top-level menu with three game modes."""
     rows = [
         [InlineKeyboardButton("📘 Флэш-карточки", callback_data="menu:cards")],
         [InlineKeyboardButton("⏱ Игра на время", callback_data="menu:sprint")],
         [InlineKeyboardButton("🤝 Дуэт против Бота", callback_data="menu:coop")],
     ]
     return InlineKeyboardMarkup(rows)
+
+
+CONTINENTS = [
+    "Европа",
+    "Азия",
+    "Африка",
+    "Северная Америка",
+    "Южная Америка",
+    "Океания",
+    "Весь мир",
+]
+
+
+def continent_kb(prefix: str) -> InlineKeyboardMarkup:
+    """Keyboard for choosing a continent.
+
+    ``prefix`` should be ``menu:cards`` or ``menu:sprint`` so that callback data
+    stays within the ``^menu:`` namespace while the user makes selections.
+    """
+
+    rows = [[InlineKeyboardButton(c, callback_data=f"{prefix}:{c}")] for c in CONTINENTS]
+    return InlineKeyboardMarkup(rows)
+
+
+def direction_kb(prefix: str, continent: str) -> InlineKeyboardMarkup:
+    """Keyboard for choosing question direction.
+
+    ``prefix`` is the final namespace (``cards`` or ``sprint``) so that pressing
+    a button dispatches to the respective handler via ``^cards:``/``^sprint:``.
+    """
+
+    rows = [
+        [
+            InlineKeyboardButton(
+                "Страна → столица",
+                callback_data=f"{prefix}:{continent}:country_to_capital",
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "Столица → страна",
+                callback_data=f"{prefix}:{continent}:capital_to_country",
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "Смешанный",
+                callback_data=f"{prefix}:{continent}:mixed",
+            )
+        ],
+    ]
+    return InlineKeyboardMarkup(rows)
+


### PR DESCRIPTION
## Summary
- add inline keyboards for continent and question direction choices
- extend menu handler to prompt for continent and direction and store user selection
- parse callback parameters in game handlers for cards and sprint

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c275e67ee08326a038d7e7465f8f41