### PR TITLE
Implement flash card training sessions

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -1,28 +1,164 @@
-"""Placeholder handler for the flash cards game."""
+"""Handlers for the flash-cards training mode."""
+
+import logging
+import random
+from typing import Optional
 
 from telegram import Update
 from telegram.ext import ContextTypes
 
 from app import DATA
+from .state import CardSession
+from .questions import make_card_question
+from .keyboards import cards_kb, cards_repeat_kb
+
+
+logger = logging.getLogger(__name__)
+
+
+async def _next_card(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Send the next card or finish the session if queue is empty."""
+
+    session: CardSession = context.user_data["card_session"]
+    if not session.queue:
+        await _finish_session(update, context)
+        return
+
+    item = session.queue.pop(0)
+    question = make_card_question(DATA, item, session.mode)
+    session.current = question  # dynamic attribute to store current card
+    session.stats["shown"] += 1
+
+    logger.debug(
+        "Generated card question for user %s: %s -> %s",
+        session.user_id,
+        question["prompt"],
+        question["answer"],
+    )
+
+    if update.callback_query:
+        q = update.callback_query
+        await q.edit_message_text(question["prompt"], reply_markup=cards_kb())
+    else:
+        await update.effective_message.reply_text(
+            question["prompt"], reply_markup=cards_kb()
+        )
+
+
+async def _finish_session(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Output final stats and unknown items."""
+
+    session: CardSession | None = context.user_data.get("card_session")
+    if not session:
+        return
+
+    logger.debug(
+        "Card session finished for user %s: stats=%s unknown=%d",
+        session.user_id,
+        session.stats,
+        len(session.unknown_set),
+    )
+
+    text = (
+        f"Сессия завершена. Показано: {session.stats['shown']}, "
+        f"знаю: {session.stats['known']}."
+    )
+    reply_markup = None
+    if session.unknown_set:
+        unknown_lines = []
+        for item in sorted(session.unknown_set):
+            if item in DATA.capital_by_country:
+                pair = f"{item} — {DATA.capital_by_country[item]}"
+            else:
+                pair = f"{item} — {DATA.country_by_capital[item]}"
+            unknown_lines.append(pair)
+        text += "\nНеизвестные:\n" + "\n".join(unknown_lines)
+        reply_markup = cards_repeat_kb()
+    else:
+        context.user_data.pop("card_session", None)
+
+    if update.callback_query:
+        q = update.callback_query
+        await q.edit_message_text(text, reply_markup=reply_markup)
+    else:
+        await update.effective_message.reply_text(text, reply_markup=reply_markup)
 
 
 async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
-    """Handle ``^cards:`` callbacks.
-
-    Expected callback data: ``cards:<continent>:<direction>``.
-    The selections are stored in ``user_data`` for future use.
-    """
+    """Handle all ``^cards:`` callbacks."""
 
     q = update.callback_query
     await q.answer()
-    try:
-        _, continent, direction = q.data.split(":", 2)
-    except ValueError:  # pragma: no cover - defensive
-        continent = direction = ""
 
-    context.user_data["continent"] = continent
-    context.user_data["direction"] = direction
+    parts = q.data.split(":")
+    if len(parts) == 3:
+        # Session setup: cards:<continent>:<direction>
+        _, continent, direction = parts
+        continent_filter: Optional[str] = None if continent == "Весь мир" else continent
+        queue = DATA.items(continent_filter, direction)
+        random.shuffle(queue)
+        session = CardSession(
+            user_id=update.effective_user.id,
+            continent_filter=continent_filter,
+            mode=direction,
+            queue=queue,
+        )
+        context.user_data["card_session"] = session
+        logger.debug(
+            "Card session started for user %s: continent=%s mode=%s total=%d",
+            session.user_id,
+            continent_filter,
+            direction,
+            len(queue),
+        )
+        await _next_card(update, context)
+        return
 
-    await q.edit_message_text(
-        f"Карточки: континент {continent or '—'}, режим {direction or '—'}."
-    )
+    # Ongoing session actions
+    action = parts[1]
+    session: CardSession | None = context.user_data.get("card_session")
+    if not session or not hasattr(session, "current"):
+        await q.edit_message_text("Сессия не найдена")
+        return
+
+    current = session.current
+    if action == "show":
+        await q.edit_message_text(
+            f"{current['prompt']}\n\n<b>{current['answer']}</b>",
+            parse_mode="HTML",
+            reply_markup=cards_kb(),
+        )
+        return
+
+    if action == "know":
+        session.stats["known"] += 1
+        await _next_card(update, context)
+        return
+
+    if action == "dont":
+        item = current["country"] if current["type"] == "country_to_capital" else current["capital"]
+        session.unknown_set.add(item)
+        await _next_card(update, context)
+        return
+
+    if action == "skip":
+        item = current["country"] if current["type"] == "country_to_capital" else current["capital"]
+        session.queue.append(item)
+        await _next_card(update, context)
+        return
+
+    if action == "finish":
+        await _finish_session(update, context)
+        context.user_data.pop("card_session", None)
+        return
+
+    if action == "repeat" and session.unknown_set:
+        session.queue = list(session.unknown_set)
+        random.shuffle(session.queue)
+        session.unknown_set.clear()
+        session.stats = {"shown": 0, "known": 0}
+        await _next_card(update, context)
+        return
+
+    await q.answer()
+

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -64,3 +64,26 @@ def direction_kb(prefix: str, continent: str) -> InlineKeyboardMarkup:
     ]
     return InlineKeyboardMarkup(rows)
 
+
+def cards_kb() -> InlineKeyboardMarkup:
+    """Controls for a flash-card question."""
+    rows = [
+        [InlineKeyboardButton("Показать ответ", callback_data="cards:show")],
+        [
+            InlineKeyboardButton("✅ Знаю", callback_data="cards:know"),
+            InlineKeyboardButton("❌ Не знаю", callback_data="cards:dont"),
+        ],
+        [InlineKeyboardButton("Пропустить", callback_data="cards:skip")],
+        [InlineKeyboardButton("Завершить", callback_data="cards:finish")],
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
+def cards_repeat_kb() -> InlineKeyboardMarkup:
+    """Keyboard shown after session to repeat unknown cards."""
+    rows = [
+        [InlineKeyboardButton("Повторить", callback_data="cards:repeat")],
+        [InlineKeyboardButton("Завершить", callback_data="cards:finish")],
+    ]
+    return InlineKeyboardMarkup(rows)
+

--- a/bot/questions.py
+++ b/bot/questions.py
@@ -41,3 +41,38 @@ def pick_question(data: DataSource, continent: str | None, mode: str):
         "correct": correct,
         "options": options,
     }
+
+
+def make_card_question(data: DataSource, item: str, mode: str):
+    """Return a flash-card style question for a specific item.
+
+    ``item`` is either a country or a capital depending on ``mode``. For the
+    mixed mode the direction is determined by the type of ``item`` itself.
+    The returned dictionary mirrors :func:`pick_question` but without
+    distractors.
+    """
+
+    question_type = mode
+    if mode == "mixed":
+        question_type = (
+            "country_to_capital" if item in data.capital_by_country else "capital_to_country"
+        )
+
+    if question_type == "country_to_capital":
+        country = item
+        capital = data.capital_by_country[country]
+        prompt = f"Какая столица у {country}?"
+        answer = capital
+    else:
+        capital = item
+        country = data.country_by_capital[capital]
+        prompt = f"К какой стране относится {capital}?"
+        answer = country
+
+    return {
+        "type": question_type,
+        "country": country,
+        "capital": capital,
+        "prompt": prompt,
+        "answer": answer,
+    }


### PR DESCRIPTION
## Summary
- add flash-card session handler that tracks queue, stats and unknown items with repeat option
- generate card prompts via questions module respecting continent and direction
- provide card control keyboards for show answer, know/unknown, skip, finish

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_e_68c278a809e48326abc12dabe55304f5