### PR TITLE
Implement sprint mode with timer and scoring

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -87,3 +87,15 @@ def cards_repeat_kb() -> InlineKeyboardMarkup:
     ]
     return InlineKeyboardMarkup(rows)
 
+
+def sprint_kb(options: list[str], allow_skip: bool = True) -> InlineKeyboardMarkup:
+    """Keyboard for sprint questions with four options and optional skip."""
+    buttons = [
+        InlineKeyboardButton(opt, callback_data=f"sprint:opt:{i}")
+        for i, opt in enumerate(options)
+    ]
+    rows = [buttons[:2], buttons[2:4]]
+    if allow_skip:
+        rows.append([InlineKeyboardButton("Пропустить", callback_data="sprint:skip")])
+    return InlineKeyboardMarkup(rows)
+


### PR DESCRIPTION
## Summary
- Add sprint question keyboard with optional skip
- Implement full sprint gameplay with timer, scoring, and logging
- Record sprint results per user for future stats

## Testing
- `python -m pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c27a128408832699552a5a8820f04e