### PR TITLE
Add user statistics tracking and /stats command

### DIFF
--- a/app.py
+++ b/app.py
@@ -58,6 +58,7 @@ from bot.handlers_menu import cmd_start, cb_menu
 from bot.handlers_cards import cb_cards
 from bot.handlers_sprint import cb_sprint
 from bot.handlers_coop import cb_coop, cmd_coop_capitals, cmd_coop_test
+from bot.handlers_stats import cmd_stats
 
 # Register handlers
 application.add_handler(CommandHandler("start", cmd_start))
@@ -67,6 +68,7 @@ application.add_handler(CallbackQueryHandler(cb_sprint, pattern="^sprint:"))
 application.add_handler(CallbackQueryHandler(cb_coop, pattern="^coop:"))
 application.add_handler(CommandHandler("coop_capitals", cmd_coop_capitals))
 application.add_handler(CommandHandler("coop_test", cmd_coop_test))
+application.add_handler(CommandHandler("stats", cmd_stats))
 
 
 async def check_webhook(context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -8,7 +8,7 @@ from telegram import Update
 from telegram.ext import ContextTypes
 
 from app import DATA
-from .state import CardSession
+from .state import CardSession, add_to_repeat, get_user_stats
 from .questions import make_card_question
 from .keyboards import cards_kb, cards_repeat_kb
 
@@ -131,13 +131,24 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
 
     if action == "know":
+        item = (
+            current["country"]
+            if current["type"] == "country_to_capital"
+            else current["capital"]
+        )
+        get_user_stats(context.user_data).to_repeat.discard(item)
         session.stats["known"] += 1
         await _next_card(update, context)
         return
 
     if action == "dont":
-        item = current["country"] if current["type"] == "country_to_capital" else current["capital"]
+        item = (
+            current["country"]
+            if current["type"] == "country_to_capital"
+            else current["capital"]
+        )
         session.unknown_set.add(item)
+        add_to_repeat(context.user_data, {item})
         await _next_card(update, context)
         return
 

--- a/bot/handlers_sprint.py
+++ b/bot/handlers_sprint.py
@@ -7,7 +7,7 @@ from telegram import Update
 from telegram.ext import ContextTypes
 
 from app import DATA
-from .state import SprintSession
+from .state import SprintSession, record_sprint_result
 from .questions import pick_question
 from .keyboards import sprint_kb
 
@@ -55,8 +55,7 @@ async def _sprint_timeout(context: ContextTypes.DEFAULT_TYPE) -> None:
         f"⏱ Время вышло! Ваш результат: {session.score} правильных из {session.questions_asked}",
     )
 
-    results = user_data.setdefault("sprint_results", [])
-    results.append({"score": session.score, "total": session.questions_asked})
+    record_sprint_result(user_data, session.score, session.questions_asked)
 
     user_data.pop("sprint_session", None)
 

--- a/bot/handlers_stats.py
+++ b/bot/handlers_stats.py
@@ -1,0 +1,29 @@
+"""Handlers for statistics commands."""
+
+from telegram import Update
+from telegram.ext import ContextTypes
+
+from .state import get_user_stats
+
+
+async def cmd_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Display aggregated per-user statistics."""
+
+    stats = get_user_stats(context.user_data)
+    total_sprints = len(stats.sprint_results)
+    best_score = best_total = 0
+    if stats.sprint_results:
+        best = max(stats.sprint_results, key=lambda r: r.score)
+        best_score = best.score
+        best_total = best.total
+
+    lines = ["📊 Ваша статистика:"]
+    lines.append(f"Спринтов сыграно: {total_sprints}")
+    if total_sprints:
+        lines.append(f"Лучший результат: {best_score} из {best_total}")
+    lines.append(f"Карточек к повторению: {len(stats.to_repeat)}")
+    if stats.to_repeat:
+        sample = list(sorted(stats.to_repeat))[:10]
+        lines.append("\n".join(["К повторению:"] + sample))
+
+    await update.effective_message.reply_text("\n".join(lines))


### PR DESCRIPTION
## Summary
- track per-user sprint results and flashcard repeat lists
- add `/stats` command to display aggregated user stats
- prepare JSON-based storage abstraction for future persistence

## Testing
- `python -m py_compile bot/state.py bot/handlers_cards.py bot/handlers_sprint.py bot/handlers_stats.py app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c28341a400832687e535fd515c3e73