### PR TITLE
Add country flag helper and integrate in quiz flows

### DIFF
--- a/bot/flags.py
+++ b/bot/flags.py
@@ -1,0 +1,36 @@
+"""Utility helpers for country flags."""
+from __future__ import annotations
+
+from functools import lru_cache
+
+try:  # optional dependency
+    import country_converter as coco  # type: ignore
+except Exception:  # pragma: no cover - library may be missing
+    coco = None  # type: ignore
+
+
+def _code_to_flag(code: str) -> str:
+    """Convert ISO alpha-2 country code to an emoji flag."""
+    return ''.join(chr(0x1F1E6 + ord(c) - ord('A')) for c in code.upper())
+
+
+@lru_cache(maxsize=None)
+def get_country_flag(country: str) -> str:
+    """Return emoji flag for given country name.
+
+    Uses :mod:`country_converter` if available to translate the country name
+    (in various languages, including Russian) into an ISO alpha-2 code.
+    If conversion fails or the library is missing, returns an empty string.
+    """
+
+    if not country:
+        return ""
+
+    if coco is not None:
+        try:
+            code = coco.convert(names=country, to="ISO2", not_found=None)
+            if isinstance(code, str) and len(code) == 2:
+                return _code_to_flag(code)
+        except Exception:
+            pass
+    return ""

--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -11,6 +11,7 @@ from app import DATA
 from .state import CardSession, add_to_repeat, get_user_stats
 from .questions import make_card_question
 from .keyboards import cards_kb, cards_repeat_kb
+from .flags import get_country_flag
 
 
 logger = logging.getLogger(__name__)
@@ -68,9 +69,12 @@ async def _finish_session(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         unknown_lines = []
         for item in sorted(session.unknown_set):
             if item in DATA.capital_by_country:
-                pair = f"{item} — {DATA.capital_by_country[item]}"
+                flag = get_country_flag(item)
+                pair = f"{flag} {item} — {DATA.capital_by_country[item]}".strip()
             else:
-                pair = f"{item} — {DATA.country_by_capital[item]}"
+                country = DATA.country_by_capital[item]
+                flag = get_country_flag(country)
+                pair = f"{item} — {flag} {country}".strip()
             unknown_lines.append(pair)
         text += "\nНеизвестные:\n" + "\n".join(unknown_lines)
         reply_markup = cards_repeat_kb()

--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -19,6 +19,7 @@ from .keyboards import (
     coop_difficulty_kb,
     coop_answer_kb,
 )
+from .flags import get_country_flag
 
 
 ADMIN_ID = int(os.getenv("ADMIN_ID", "0"))
@@ -246,11 +247,18 @@ async def cb_coop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         if bot_correct:
             session.bot_score += 1
 
+        if session.current_question["type"] == "country_to_capital":
+            country = session.current_question["country"]
+            flag = get_country_flag(country)
+            correct_display = f"{session.current_question['correct']} — {flag} {country}".strip()
+        else:
+            correct_display = session.current_question["correct"]
+
         await context.bot.send_message(
             session.chat_id,
             (
                 f"Бот {'угадал' if bot_correct else 'ошибся'} — правильный ответ: "
-                f"{session.current_question['correct']}\n"
+                f"{correct_display}\n"
                 f"Счёт: Команда {session.team_score} — Бот {session.bot_score} "
                 f"(Раунд {session.current_round}/{session.total_rounds})"
             ),

--- a/bot/handlers_stats.py
+++ b/bot/handlers_stats.py
@@ -3,7 +3,9 @@
 from telegram import Update
 from telegram.ext import ContextTypes
 
+from app import DATA
 from .state import get_user_stats
+from .flags import get_country_flag
 
 
 async def cmd_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -24,6 +26,13 @@ async def cmd_stats(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     lines.append(f"Карточек к повторению: {len(stats.to_repeat)}")
     if stats.to_repeat:
         sample = list(sorted(stats.to_repeat))[:10]
-        lines.append("\n".join(["К повторению:"] + sample))
+        lines.append("К повторению:")
+        for item in sample:
+            if item in DATA.capital_by_country:
+                lines.append(f"{get_country_flag(item)} {item}".strip())
+            else:
+                country = DATA.country_by_capital[item]
+                flag = get_country_flag(country)
+                lines.append(f"{item} — {flag} {country}".strip())
 
     await update.effective_message.reply_text("\n".join(lines))

--- a/bot/questions.py
+++ b/bot/questions.py
@@ -1,6 +1,7 @@
 import random
 
 from .state import DataSource
+from .flags import get_country_flag
 
 
 def pick_question(data: DataSource, continent: str | None, mode: str):
@@ -29,9 +30,12 @@ def pick_question(data: DataSource, continent: str | None, mode: str):
     random.shuffle(options)
 
     if question_type == "country_to_capital":
-        prompt = f"Какая столица у {country}?"
+        flag = get_country_flag(country)
+        prompt = f"Какая столица у {flag} {country}?".strip()
     else:
         prompt = f"К какой стране относится {capital}?"
+        correct = f"{get_country_flag(correct)} {correct}".strip()
+        options = [f"{get_country_flag(o)} {o}".strip() for o in options]
 
     return {
         "type": question_type,
@@ -61,13 +65,14 @@ def make_card_question(data: DataSource, item: str, mode: str):
     if question_type == "country_to_capital":
         country = item
         capital = data.capital_by_country[country]
-        prompt = f"Какая столица у {country}?"
+        flag = get_country_flag(country)
+        prompt = f"Какая столица у {flag} {country}?".strip()
         answer = capital
     else:
         capital = item
         country = data.country_by_capital[capital]
         prompt = f"К какой стране относится {capital}?"
-        answer = country
+        answer = f"{get_country_flag(country)} {country}".strip()
 
     return {
         "type": question_type,


### PR DESCRIPTION
## Summary
- add `get_country_flag` utility with optional ISO code lookup
- show country flags in questions, answers, stats and session summaries
- display correct answers with flags in cooperative mode

## Testing
- `python -m py_compile bot/flags.py bot/questions.py bot/handlers_cards.py bot/handlers_stats.py bot/handlers_coop.py`
- `pip install country_converter` *(fails: Could not find a version that satisfies the requirement)*

------
https://chatgpt.com/codex/tasks/task_e_68c28d3ee6d483268c06bc19659f9e99