### PR TITLE
Ensure Application lifecycle startup/stop in FastAPI webhook

### DIFF
--- a/app.py
+++ b/app.py
@@ -126,6 +126,11 @@ async def telegram_webhook(request: Request):
     if token != WEBHOOK_SECRET:
         raise HTTPException(403, "forbidden")
 
+    if not getattr(application, "_initialized", False):
+        await application.initialize()
+    if not application.running:
+        await application.start()
+
     data = await request.json()
     update = Update.de_json(data, application.bot)
     await application.process_update(update)


### PR DESCRIPTION
## Summary
- Check for uninitialized Application in `/webhook` handler and call `initialize()`/`start()` as needed
- Confirm startup hook runs `initialize()` and `start()` and shutdown hook stops Application

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c29213aa308326960a91498f4ecb74