### PR TITLE
Guard webhook scheduler and add job-queue dependency

### DIFF
--- a/app.py
+++ b/app.py
@@ -167,9 +167,14 @@ async def on_startup():
     else:
         logger.warning("PUBLIC_URL is not set; webhook check skipped")
 
-    application.job_queue.run_repeating(
-        check_webhook, interval=600, first=600
-    )
+    if application.job_queue:
+        application.job_queue.run_repeating(
+            check_webhook, interval=600, first=600
+        )
+    else:
+        logger.warning(
+            "Job queue is not available; skipping webhook check scheduling"
+        )
 
 @app.on_event("shutdown")
 async def on_shutdown():

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-python-telegram-bot>=20.6
+python-telegram-bot[job-queue]>=20.6
 fastapi>=0.110
 uvicorn>=0.30
 pydantic>=2.6


### PR DESCRIPTION
## Summary
- Ensure app startup checks for available job queue before scheduling webhook verification
- Add APScheduler-backed job queue dependency for python-telegram-bot

## Testing
- `python -m py_compile app.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2b148451c8326984b49192fc07194