### PR TITLE
Show correct feedback in alert popups

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -162,7 +162,7 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         if selected == current["answer"]:
             get_user_stats(context.user_data).to_repeat.discard(item)
             session.stats["known"] += 1
-            await q.answer("✅ Верно")
+            await q.answer("✅ Верно", show_alert=True)
         else:
             session.unknown_set.add(item)
             add_to_repeat(context.user_data, {item})

--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -274,7 +274,7 @@ async def cb_coop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         correct = option == session.current_question["correct"]
         if correct:
             session.team_score += 1
-            await q.answer("✅ Верно")
+            await q.answer("✅ Верно", show_alert=True)
         else:
             await q.answer(
                 f"❌ Неверно. Правильный ответ: {session.current_question['correct']}",

--- a/bot/handlers_sprint.py
+++ b/bot/handlers_sprint.py
@@ -127,7 +127,7 @@ async def cb_sprint(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         session.questions_asked += 1
         if option == session.current["correct"]:
             session.score += 1
-            await q.answer("✅ Верно")
+            await q.answer("✅ Верно", show_alert=True)
             logger.debug(
                 "Sprint correct answer by user %s: score=%d questions=%d",
                 session.user_id,


### PR DESCRIPTION
## Summary
- Show alert popups for correct answers in flash cards
- Apply same alert behavior to sprint mode
- Ensure coop mode uses alerts for correct answers

## Testing
- `python -m py_compile bot/handlers_cards.py bot/handlers_sprint.py bot/handlers_coop.py`


------
https://chatgpt.com/codex/tasks/task_e_68c2eceaee508326bf4537bc3924fa57