### PR TITLE
Simplify sprint setup and defaults

### DIFF
--- a/bot/handlers_menu.py
+++ b/bot/handlers_menu.py
@@ -3,7 +3,7 @@
 from telegram import Update
 from telegram.ext import ContextTypes
 
-from .keyboards import main_menu_kb, continent_kb, direction_kb
+from .keyboards import main_menu_kb, continent_kb, direction_kb, sprint_duration_kb
 
 WELCOME = (
     "Привет! Это бот для тренировки знаний столицы ↔ страна.\n"
@@ -26,14 +26,22 @@ async def cb_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
         text = "📘 Флэш-карточки: выбери континент." if mode == "cards" else "⏱ Игра на время: выбери континент."
         await q.edit_message_text(text, reply_markup=continent_kb(f"menu:{mode}"))
 
-    elif data.startswith("menu:cards:") or data.startswith("menu:sprint:"):
+    elif data.startswith("menu:cards:"):
         parts = data.split(":", 2)
-        mode = parts[1]
         continent = parts[2]
         context.user_data["continent"] = continent
         await q.edit_message_text(
             "Выбери направление вопросов:",
-            reply_markup=direction_kb(mode, continent),
+            reply_markup=direction_kb("cards", continent),
+        )
+
+    elif data.startswith("menu:sprint:"):
+        parts = data.split(":", 2)
+        continent = parts[2]
+        context.user_data["continent"] = continent
+        await q.edit_message_text(
+            "Выбери длительность спринта:",
+            reply_markup=sprint_duration_kb(continent),
         )
 
     elif data == "menu:coop":

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -84,6 +84,17 @@ def direction_kb(prefix: str, continent: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(rows)
 
 
+def sprint_duration_kb(continent: str) -> InlineKeyboardMarkup:
+    """Keyboard for choosing sprint duration."""
+
+    rows = [
+        [InlineKeyboardButton("30 секунд", callback_data=f"sprint:{continent}:30")],
+        [InlineKeyboardButton("60 секунд", callback_data=f"sprint:{continent}:60")],
+        [InlineKeyboardButton("90 секунд", callback_data=f"sprint:{continent}:90")],
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
 def cards_kb(options: list[str]) -> InlineKeyboardMarkup:
     """Keyboard for flash-card questions with answer options."""
     wrapped = [wrap_button_text(opt) for opt in options]


### PR DESCRIPTION
## Summary
- add sprint duration keyboard and callbacks
- default sprint questions to mixed mode
- remove direction step from sprint menu and launch after duration selection

## Testing
- `python -m py_compile bot/handlers_menu.py bot/handlers_sprint.py bot/keyboards.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c2fad23e4883268b5ac9c494ee4f98