### PR TITLE
Add menu return option for flash cards

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -119,7 +119,7 @@ def cards_repeat_kb() -> InlineKeyboardMarkup:
     """Keyboard shown after session to repeat unknown cards."""
     rows = [
         [InlineKeyboardButton("Повторить", callback_data="cards:repeat")],
-        [InlineKeyboardButton("Завершить", callback_data="cards:finish")],
+        [InlineKeyboardButton("В меню", callback_data="cards:menu")],
     ]
     return InlineKeyboardMarkup(rows)
 


### PR DESCRIPTION
## Summary
- Replace "Завершить" button with "В меню" in cards_repeat_kb and handle new callback
- Preserve card session after finishing so users can review unknown cards again
- Allow returning to main menu with new "menu" action

## Testing
- `python -m py_compile bot/keyboards.py bot/handlers_cards.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c30f820f348326871a45f26ddafef5