### PR TITLE
Add continue button after showing answer

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -12,7 +12,7 @@ from httpx import HTTPError
 from app import DATA
 from .state import CardSession, add_to_repeat, get_user_stats
 from .questions import make_card_question
-from .keyboards import cards_kb, cards_repeat_kb, main_menu_kb
+from .keyboards import cards_kb, cards_repeat_kb, main_menu_kb, cards_answer_kb
 from .flags import get_country_flag
 from .handlers_menu import WELCOME
 
@@ -190,7 +190,7 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             await q.edit_message_text(
                 f"{current['prompt']}\n\n<b>{current['answer']}</b>",
                 parse_mode="HTML",
-                reply_markup=cards_kb(current["options"]),
+                reply_markup=cards_answer_kb(),
             )
         except BadRequest:
             logger.debug(
@@ -199,6 +199,11 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         except (TelegramError, HTTPError) as e:
             logger.warning("Failed to show answer: %s", e)
             return
+        return
+
+    if action == "next":
+        await q.answer()
+        await _next_card(update, context)
         return
 
     if action == "skip":

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -115,6 +115,15 @@ def cards_kb(options: list[str]) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(rows)
 
 
+def cards_answer_kb() -> InlineKeyboardMarkup:
+    """Keyboard shown after revealing the answer."""
+    rows = [
+        [InlineKeyboardButton("Продолжить", callback_data="cards:next")],
+        [InlineKeyboardButton("Завершить", callback_data="cards:finish")],
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
 def cards_repeat_kb() -> InlineKeyboardMarkup:
     """Keyboard shown after session to repeat unknown cards."""
     rows = [


### PR DESCRIPTION
## Summary
- Add keyboard with "Продолжить" and "Завершить" buttons for flashcards after revealing the answer
- Replace answer options with new keyboard and handle "cards:next" action to move to the next card

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c31e413880832692c03ed8e65cb995