### PR TITLE
Adjust formatting for wrong-answer alerts

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -170,7 +170,7 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             session.unknown_set.add(item)
             add_to_repeat(context.user_data, {item})
             await q.answer(
-                f"❌ Неверно. Правильный ответ: {current['answer']}",
+                f"❌ Неверно.\nПравильный ответ:\n{current['answer']}",
                 show_alert=True,
             )
         await _next_card(update, context)

--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -277,7 +277,7 @@ async def cb_coop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             await q.answer("✅ Верно", show_alert=True)
         else:
             await q.answer(
-                f"❌ Неверно. Правильный ответ: {session.current_question['correct']}",
+                f"❌ Неверно.\nПравильный ответ:\n{session.current_question['correct']}",
                 show_alert=True,
             )
 

--- a/bot/handlers_sprint.py
+++ b/bot/handlers_sprint.py
@@ -137,7 +137,7 @@ async def cb_sprint(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             )
         else:
             await q.answer(
-                f"❌ Неверно. Правильный ответ: {session.current['correct']}",
+                f"❌ Неверно.\nПравильный ответ:\n{session.current['correct']}",
                 show_alert=True,
             )
             logger.debug(


### PR DESCRIPTION
## Summary
- improve incorrect-answer alerts by placing the flag and country on a new line
- ensure the preamble before the correct answer is regular font and not bold

## Testing
- `python -m py_compile bot/handlers_cards.py bot/handlers_sprint.py bot/handlers_coop.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c3e2be104c83269b816283f364a378