### PR TITLE
Add Swift wrong answer alert example

### DIFF
--- a/show_wrong_answer_alert.swift
+++ b/show_wrong_answer_alert.swift
@@ -1,0 +1,10 @@
+func showWrongAnswerAlert() {
+    let alert = UIAlertController(
+        title: "❌ Неверно.",
+        message: "Правильный ответ:\n🇲🇿 Мозамбик",
+        preferredStyle: .alert
+    )
+
+    alert.addAction(UIAlertAction(title: "OK", style: .default))
+    present(alert, animated: true)
+}


### PR DESCRIPTION
## Summary
- add a Swift function demonstrating a wrong-answer alert

## Testing
- `python -m py_compile $(git ls-files '*.py')`


------
https://chatgpt.com/codex/tasks/task_e_68c3e5a71ffc832683a240524618276e