### PR TITLE
Keep flag with first word in button text wrapping

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -1,13 +1,26 @@
 """Inline keyboards used across the bot menus."""
 
 from telegram import InlineKeyboardMarkup, InlineKeyboardButton
+import unicodedata
 
 
 def wrap_button_text(text: str, limit: int = 20) -> str:
-    """Insert line breaks so that each line is at most *limit* chars."""
+    """Insert line breaks so that each line is at most *limit* chars.
+
+    If the text starts with an emoji (such as a country flag), the emoji and
+    the first word are kept together before applying wrapping. This prevents
+    splits like "🇨🇫\nЦентральноафриканская".
+    """
     words = text.split()
     if not words:
         return text
+
+    def _is_emoji(token: str) -> bool:
+        return all(unicodedata.category(ch) == "So" for ch in token)
+
+    if len(words) > 1 and _is_emoji(words[0]):
+        words[0] = f"{words[0]} {words[1]}"
+        del words[1]
 
     lines: list[str] = []
     current = words[0]


### PR DESCRIPTION
## Summary
- Preserve leading emoji (like country flags) with following word when wrapping button text
- Document this behavior in the wrap helper

## Testing
- `python -m py_compile bot/keyboards.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3e90ff238832693c72a735b804ed6