### PR TITLE
Add finish session keyboard and menu callback handling

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -146,6 +146,12 @@ def cards_repeat_kb() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(rows)
 
 
+def cards_finish_kb() -> InlineKeyboardMarkup:
+    """Keyboard shown after session with no unknown cards."""
+    rows = [[InlineKeyboardButton("В меню", callback_data="cards:menu")]]
+    return InlineKeyboardMarkup(rows)
+
+
 def sprint_kb(options: list[str], allow_skip: bool = True) -> InlineKeyboardMarkup:
     """Keyboard for sprint questions with four options and optional skip."""
     wrapped = [wrap_button_text(opt) for opt in options]


### PR DESCRIPTION
## Summary
- Add `cards_finish_kb` keyboard to return users to main menu when session ends without unknown cards
- Use `cards_finish_kb` in session finishing logic and only show repeat keyboard when needed
- Handle `cards:menu` callback even when no active session and remove redundant branch

## Testing
- `python -m py_compile bot/keyboards.py bot/handlers_cards.py`


------
https://chatgpt.com/codex/tasks/task_e_68c3e9cf35b48326886107987c146238