### PR TITLE
feat: add spacer between answer and menu buttons

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -128,6 +128,9 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     q = update.callback_query
 
     parts = q.data.split(":")
+    if parts == ["cards", "void"]:
+        await q.answer()
+        return
     if parts == ["cards", "menu"]:
         await q.answer()
         context.user_data.pop("card_session", None)

--- a/bot/handlers_sprint.py
+++ b/bot/handlers_sprint.py
@@ -83,6 +83,9 @@ async def cb_sprint(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     parts = q.data.split(":")
     action = parts[1]
+    if action == "void":
+        await q.answer()
+        return
     if action not in {"opt", "skip"}:
         await q.answer()
         # Session setup: sprint:<continent>:<duration>

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -100,7 +100,8 @@ def cards_kb(options: list[str]) -> InlineKeyboardMarkup:
                 buffer = []
     if buffer:
         rows.append(buffer)
-
+    # spacer row to visually separate options from action buttons
+    rows.append([InlineKeyboardButton(" ", callback_data="cards:void")])
     rows.append([InlineKeyboardButton("Показать ответ", callback_data="cards:show")])
     rows.append([InlineKeyboardButton("Пропустить", callback_data="cards:skip")])
     rows.append([InlineKeyboardButton("Завершить", callback_data="cards:finish")])
@@ -152,6 +153,7 @@ def sprint_kb(options: list[str], allow_skip: bool = True) -> InlineKeyboardMark
     if buffer:
         rows.append(buffer)
     if allow_skip:
+        rows.append([InlineKeyboardButton(" ", callback_data="sprint:void")])
         rows.append([InlineKeyboardButton("Пропустить", callback_data="sprint:skip")])
     return InlineKeyboardMarkup(rows)
 


### PR DESCRIPTION
## Summary
- visually separate answer options from menu buttons with an empty spacer row
- ignore new spacer callbacks in flash cards and sprint handlers

## Testing
- `python -m py_compile bot/keyboards.py bot/handlers_cards.py bot/handlers_sprint.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c4039a75b4832695326fc26683f25b