### PR TITLE
Include missed questions and restart options in sprint results

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -157,6 +157,20 @@ def sprint_kb(options: list[str], allow_skip: bool = True) -> InlineKeyboardMark
     return InlineKeyboardMarkup(rows)
 
 
+def sprint_result_kb(continent: str) -> InlineKeyboardMarkup:
+    """Keyboard shown after sprint results.
+
+    Provides a quick restart for the same continent and a button to return to
+    the main menu.
+    """
+
+    rows = [
+        [InlineKeyboardButton("Играть еще раз", callback_data=f"sprint:{continent}")],
+        [InlineKeyboardButton("В меню", callback_data="sprint:menu")],
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
 # ===== Cooperative mode keyboards =====
 
 


### PR DESCRIPTION
## Summary
- Track skipped sprint questions and display them alongside incorrect answers with country flags
- Provide `Играть еще раз` and `В меню` buttons after sprint results for quick restart or returning to main menu

## Testing
- `python -m py_compile bot/handlers_sprint.py bot/keyboards.py`
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c41358be748326a78b80b73ea1d3b1