### PR TITLE
Avoid repeating countries in sprint questions

### DIFF
--- a/bot/handlers_sprint.py
+++ b/bot/handlers_sprint.py
@@ -23,8 +23,11 @@ async def _ask_question(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     """Generate and send the next sprint question."""
 
     session: SprintSession = context.user_data["sprint_session"]
-    question = pick_question(DATA, session.continent_filter, session.mode)
+    question = pick_question(
+        DATA, session.continent_filter, session.mode, session.asked_countries
+    )
     session.current = question
+    session.asked_countries.add(question["country"])
 
     allow_skip = context.user_data.get("sprint_allow_skip", True)
     reply_markup = sprint_kb(question["options"], allow_skip)

--- a/bot/questions.py
+++ b/bot/questions.py
@@ -4,12 +4,21 @@ from .state import DataSource
 from .flags import get_country_flag
 
 
-def pick_question(data: DataSource, continent: str | None, mode: str):
+def pick_question(
+    data: DataSource,
+    continent: str | None,
+    mode: str,
+    asked_countries: set[str] | None = None,
+):
     """Generate a question based on the provided mode."""
     # mode: "country_to_capital" | "capital_to_country" | "mixed"
     countries = data.countries(continent)
+    if asked_countries:
+        countries = [c for c in countries if c not in asked_countries]
     if not countries:
-        raise RuntimeError("No countries for selected continent")
+        countries = data.countries(continent)
+        if asked_countries is not None:
+            asked_countries.clear()
 
     country = random.choice(countries)
     capital = data.capital_by_country[country]

--- a/bot/state.py
+++ b/bot/state.py
@@ -106,6 +106,7 @@ class SprintSession:
     score: int = 0
     questions_asked: int = 0
     wrong_answers: list[tuple[str, str]] = field(default_factory=list)
+    asked_countries: set[str] = field(default_factory=set)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Track countries already asked during a sprint session
- Exclude previously asked countries when generating new sprint questions

## Testing
- `python -m py_compile bot/state.py bot/questions.py bot/handlers_sprint.py`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c51f70dd508326bad4d9a74c8d1f69