### PR TITLE
Add generate-facts workflow

### DIFF
--- a/.github/workflows/generate-facts.yml
+++ b/.github/workflows/generate-facts.yml
@@ -1,3 +1,20 @@
+name: Generate Facts
 on:
   schedule:
-    - cron: "0 3 * * 1"   # каждый понедельник в 03:00 UTC
+    - cron: "0 3 * * 1"   # каждое понедельник 03:00 UTC
+jobs:
+  generate-facts:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/setup-python@v4
+        with:
+          python-version: "3.11"
+      - run: pip install -r requirements.txt
+      - run: python scripts/generate_facts.py
+        env:
+          OPENAI_API_KEY: ${{ secrets.OPENAI_API_KEY }}
+      - uses: actions/upload-artifact@v3
+        with:
+          name: facts
+          path: data/facts.json


### PR DESCRIPTION
## Summary
- schedule weekly GitHub Action to generate facts using Python 3.11
- install dependencies, run `scripts/generate_facts.py`, and upload generated facts as artifact

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5368d77b4832680199d9dff5aeeae