### PR TITLE
Add persistent facts cache with TTL and preload

### DIFF
--- a/app.py
+++ b/app.py
@@ -13,6 +13,7 @@ from telegram.ext import (
 )
 
 from bot.utils import tg_call
+from bot.facts import preload_facts
 
 # ===== ENV =====
 load_dotenv()
@@ -195,6 +196,9 @@ async def on_startup():
             )
     else:
         logger.warning("PUBLIC_URL is not set; webhook check skipped")
+
+    # preload facts asynchronously so regular handling is not blocked
+    asyncio.create_task(preload_facts(DATA.countries()))
 
     if application.job_queue:
         application.job_queue.run_repeating(

--- a/bot/facts.py
+++ b/bot/facts.py
@@ -1,47 +1,125 @@
 """Fetch and cache random facts using OpenAI.
 
-Facts are cached per subject and can be reused across modes.
+Facts are cached per subject and can be reused across modes. Cache can be
+persisted on disk via ``FACTS_CACHE_PATH`` environment variable with a
+time-to-live of 5 days.
 """
 
 from __future__ import annotations
 
+import asyncio
+import json
 import os
 import random
+from datetime import datetime, timedelta, timezone
+from pathlib import Path
+from typing import Iterable
 
 from langchain_openai import ChatOpenAI
 from langchain_core.messages import HumanMessage
 
-_cache: dict[str, list[str]] = {}
+# subject -> {"facts": [..], "updated_at": datetime}
+_cache: dict[str, dict[str, object]] = {}
+
+FACTS_TTL = timedelta(days=5)
+_cache_path_str = os.getenv("FACTS_CACHE_PATH")
+_cache_path = Path(_cache_path_str).expanduser() if _cache_path_str else None
+
+
+def _load_cache() -> None:
+    if not _cache_path or not _cache_path.exists():
+        return
+    try:
+        raw = json.loads(_cache_path.read_text(encoding="utf-8"))
+    except Exception:  # noqa: BLE001
+        return
+    now = datetime.now(timezone.utc)
+    for subject, entry in raw.items():
+        facts = entry.get("facts")
+        updated_at = entry.get("updated_at")
+        if not facts or not updated_at:
+            continue
+        try:
+            ts = datetime.fromisoformat(updated_at)
+        except ValueError:
+            continue
+        if now - ts <= FACTS_TTL:
+            _cache[subject] = {"facts": list(facts), "updated_at": ts}
+
+
+def _save_cache() -> None:
+    if not _cache_path:
+        return
+    data = {
+        subject: {
+            "facts": entry["facts"],
+            "updated_at": entry["updated_at"].isoformat(),
+        }
+        for subject, entry in _cache.items()
+    }
+    tmp = _cache_path.with_suffix(".tmp")
+    tmp.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+    os.replace(tmp, _cache_path)
+
+
+def _expired(ts: datetime) -> bool:
+    return datetime.now(timezone.utc) - ts > FACTS_TTL
+
+
+async def _fetch_facts(subject: str) -> list[str]:
+    llm = ChatOpenAI(
+        api_key=os.environ.get("OPENAI_API_KEY"), model="gpt-4o-mini"
+    )
+    prompt = f"Назови 3 интересных факта о {subject}. Каждая строка ≤150 символов"
+    response = await llm.ainvoke([HumanMessage(content=prompt)])
+    content = getattr(response, "content", "")
+    lines = [line.strip() for line in content.splitlines() if line.strip()]
+    return [line[:150] for line in lines][:3]
+
+
+async def ensure_facts(subject: str) -> list[str]:
+    entry = _cache.get(subject)
+    if entry and not _expired(entry["updated_at"]):
+        return entry["facts"]  # type: ignore[return-value]
+
+    facts = await _fetch_facts(subject)
+    if not facts:
+        raise RuntimeError("no facts returned")
+    entry = {"facts": facts, "updated_at": datetime.now(timezone.utc)}
+    _cache[subject] = entry
+    _save_cache()
+    return facts
 
 
 async def get_random_fact(subject: str) -> str:
     """Return a random fact about ``subject`` using OpenAI.
 
-    Facts are cached per subject to avoid repeated API calls. Each fact is
+    Facts are cached per subject with optional persistence. Each fact is
     truncated to 150 characters. On any error a fallback string is returned.
     """
 
-    facts = _cache.get(subject)
-    if not facts:
-        try:
-            llm = ChatOpenAI(
-                api_key=os.environ.get("OPENAI_API_KEY"), model="gpt-4o-mini"
-            )
-            prompt = (
-                f"Назови 3 интересных факта о {subject}. Каждая строка ≤150 символов"
-            )
-            response = await llm.ainvoke([HumanMessage(content=prompt)])
-            content = getattr(response, "content", "")
-            lines = [line.strip() for line in content.splitlines() if line.strip()]
-            facts = [line[:150] for line in lines][:3]
-            if facts:
-                _cache[subject] = facts
-        except Exception:
-            return "Интересный факт недоступен"
-
-    if not facts:
+    try:
+        facts = await ensure_facts(subject)
+    except Exception:  # noqa: BLE001
         return "Интересный факт недоступен"
-    return random.choice(facts)
+    return random.choice(facts) if facts else "Интересный факт недоступен"
 
 
-__all__ = ["get_random_fact"]
+async def preload_facts(subjects: Iterable[str]) -> None:
+    """Preload facts for ``subjects`` with retries on failures."""
+
+    for subject in subjects:
+        for attempt in range(3):
+            try:
+                await ensure_facts(subject)
+                break
+            except Exception:  # noqa: BLE001
+                if attempt < 2:
+                    await asyncio.sleep(2 ** attempt)
+
+
+_load_cache()
+
+
+__all__ = ["get_random_fact", "ensure_facts", "preload_facts"]
+

--- a/tests/test_facts.py
+++ b/tests/test_facts.py
@@ -2,6 +2,8 @@ import sys
 from pathlib import Path
 import types
 import asyncio
+import json
+from datetime import datetime, timedelta, timezone
 
 import pytest
 
@@ -13,8 +15,9 @@ class _ChatOpenAI:
     def __init__(self, *args, **kwargs):
         pass
 
-    async def ainvoke(self, messages):
+    async def ainvoke(self, messages):  # pragma: no cover - replaced in tests
         raise NotImplementedError
+
 
 langchain_openai_stub = types.SimpleNamespace(ChatOpenAI=_ChatOpenAI)
 sys.modules.setdefault("langchain_openai", langchain_openai_stub)
@@ -31,7 +34,6 @@ module_messages.HumanMessage = _HumanMessage
 sys.modules.setdefault("langchain_core", types.ModuleType("langchain_core"))
 sys.modules["langchain_core.messages"] = module_messages
 
-from bot import facts
 from langchain_openai import ChatOpenAI
 
 
@@ -40,22 +42,33 @@ class DummyResponse:
         self.content = content
 
 
-def test_fact_length(monkeypatch):
+def load_facts(monkeypatch, cache_path: Path | None = None):
+    if cache_path is not None:
+        monkeypatch.setenv("FACTS_CACHE_PATH", str(cache_path))
+    else:
+        monkeypatch.delenv("FACTS_CACHE_PATH", raising=False)
+    sys.modules.pop("bot.facts", None)
+    import bot.facts as facts
+    return facts
+
+
+def test_fact_length(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "test")
+    facts = load_facts(monkeypatch, tmp_path / "cache.json")
 
     async def fake_ainvoke(self, messages):
         return DummyResponse("1. short fact\n2. " + "a" * 200 + "\n3. another short fact")
 
     monkeypatch.setattr(ChatOpenAI, "ainvoke", fake_ainvoke)
-    facts._cache.clear()
 
     fact = asyncio.run(facts.get_random_fact("кот"))
     assert len(fact) <= 150
-    assert all(len(f) <= 150 for f in facts._cache["кот"])
+    assert all(len(f) <= 150 for f in facts._cache["кот"]["facts"])
 
 
-def test_cache(monkeypatch):
+def test_cache(monkeypatch, tmp_path):
     monkeypatch.setenv("OPENAI_API_KEY", "test")
+    facts = load_facts(monkeypatch, tmp_path / "cache.json")
     calls = 0
 
     async def fake_ainvoke(self, messages):
@@ -64,9 +77,34 @@ def test_cache(monkeypatch):
         return DummyResponse("факт один\nфакт два\nфакт три")
 
     monkeypatch.setattr(ChatOpenAI, "ainvoke", fake_ainvoke)
-    facts._cache.clear()
 
     asyncio.run(facts.get_random_fact("пингвин"))
     assert calls == 1
     asyncio.run(facts.get_random_fact("пингвин"))
     assert calls == 1
+
+
+def test_cache_file_ttl(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    cache_file = tmp_path / "facts.json"
+    old = datetime.now(timezone.utc) - timedelta(days=6)
+    data = {"лиса": {"facts": ["старый факт"], "updated_at": old.isoformat()}}
+    cache_file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+    calls = 0
+
+    async def fake_ainvoke(self, messages):
+        nonlocal calls
+        calls += 1
+        return DummyResponse("новый факт1\nновый факт2\nновый факт3")
+
+    facts = load_facts(monkeypatch, cache_file)
+    monkeypatch.setattr(ChatOpenAI, "ainvoke", fake_ainvoke)
+
+    fact = asyncio.run(facts.get_random_fact("лиса"))
+    assert calls == 1
+    assert "лиса" in facts._cache
+    saved = json.loads(cache_file.read_text(encoding="utf-8"))
+    assert saved["лиса"]["updated_at"] != old.isoformat()
+    assert fact in saved["лиса"]["facts"]
+


### PR DESCRIPTION
## Summary
- cache random facts to disk with 5-day TTL and atomic save via `FACTS_CACHE_PATH`
- preload facts for all countries asynchronously on startup
- cover new caching logic with tests

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c536bfa8648326919b961e3624d7b4