### PR TITLE
feat: warn on invalid facts cache path

### DIFF
--- a/bot/facts.py
+++ b/bot/facts.py
@@ -9,6 +9,7 @@ from __future__ import annotations
 
 import asyncio
 import json
+import logging
 import os
 import random
 from datetime import datetime, timedelta, timezone
@@ -22,13 +23,48 @@ from langchain_core.messages import HumanMessage
 _cache: dict[str, dict[str, object]] = {}
 
 FACTS_TTL = timedelta(days=5)
+
+logger = logging.getLogger(__name__)
+
 _cache_path_str = os.getenv("FACTS_CACHE_PATH")
 _cache_path = Path(_cache_path_str).expanduser() if _cache_path_str else None
 
 
 def _load_cache() -> None:
-    if not _cache_path or not _cache_path.exists():
+    global _cache_path
+
+    if not _cache_path:
+        logger.warning(
+            "FACTS_CACHE_PATH env var is not set; facts cache will not persist"
+        )
         return
+
+    try:
+        _cache_path.parent.mkdir(parents=True, exist_ok=True)
+    except OSError:
+        logger.warning(
+            "FACTS_CACHE_PATH '%s' is not writable; facts cache will not persist",
+            _cache_path,
+        )
+        _cache_path = None
+        return
+
+    writable = (
+        os.access(_cache_path, os.W_OK)
+        if _cache_path.exists()
+        else os.access(_cache_path.parent, os.W_OK)
+    )
+    if not writable:
+        logger.warning(
+            "FACTS_CACHE_PATH '%s' is not writable; facts cache will not persist",
+            _cache_path,
+        )
+        _cache_path = None
+        return
+
+    if not _cache_path.exists():
+        return
+
     try:
         raw = json.loads(_cache_path.read_text(encoding="utf-8"))
     except Exception:  # noqa: BLE001


### PR DESCRIPTION
## Summary
- log warning when `FACTS_CACHE_PATH` is unset or unwritable so facts cache won't persist
- test missing/unwritable cache path scenarios

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5495148f88326b98f4ecb17e81f28