### PR TITLE
Use captions for flag messages

### DIFF
--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -279,17 +279,26 @@ async def cb_coop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             text = f"✅ Верно\n{session.current_question['country']}"
             if session.current_question["type"] == "country_to_capital":
                 text += f"\nСтолица: {session.current_question['capital']}"
-            try:
-                await context.bot.send_message(session.chat_id, text)
-            except (TelegramError, HTTPError) as e:
-                logger.warning("Failed to send coop correct message: %s", e)
             flag_path = get_flag_image_path(session.current_question["country"])
+            try:
+                await q.edit_message_reply_markup(None)
+            except (TelegramError, HTTPError) as e:
+                logger.warning("Failed to clear coop buttons: %s", e)
             if flag_path:
                 try:
                     with flag_path.open("rb") as f:
-                        await context.bot.send_photo(session.chat_id, f)
+                        await context.bot.send_photo(
+                            session.chat_id, f, caption=text
+                        )
                 except (TelegramError, HTTPError) as e:
                     logger.warning("Failed to send coop flag image: %s", e)
+            else:
+                try:
+                    await context.bot.send_message(session.chat_id, text)
+                except (TelegramError, HTTPError) as e:
+                    logger.warning(
+                        "Failed to send coop correct message: %s", e
+                    )
         else:
             await q.answer()
             try:

--- a/bot/handlers_sprint.py
+++ b/bot/handlers_sprint.py
@@ -164,17 +164,26 @@ async def cb_sprint(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             text = f"✅ Верно\n{session.current['country']}"
             if session.current["type"] == "country_to_capital":
                 text += f"\nСтолица: {session.current['capital']}"
-            try:
-                await context.bot.send_message(q.message.chat_id, text)
-            except (TelegramError, HTTPError) as e:
-                logger.warning("Failed to send sprint correct message: %s", e)
             flag_path = get_flag_image_path(session.current["country"])
+            try:
+                await q.edit_message_reply_markup(None)
+            except (TelegramError, HTTPError) as e:
+                logger.warning("Failed to clear sprint buttons: %s", e)
             if flag_path:
                 try:
                     with flag_path.open("rb") as f:
-                        await context.bot.send_photo(q.message.chat_id, f)
+                        await context.bot.send_photo(
+                            q.message.chat_id, f, caption=text
+                        )
                 except (TelegramError, HTTPError) as e:
                     logger.warning("Failed to send sprint flag image: %s", e)
+            else:
+                try:
+                    await context.bot.send_message(q.message.chat_id, text)
+                except (TelegramError, HTTPError) as e:
+                    logger.warning(
+                        "Failed to send sprint correct message: %s", e
+                    )
             logger.debug(
                 "Sprint correct answer by user %s: score=%d questions=%d",
                 session.user_id,


### PR DESCRIPTION
## Summary
- Show feedback text within flag image captions for correct answers across flash cards, sprint, and cooperative modes
- Clear inline keyboards before sending flag photos to avoid extra messages

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c560dc7e98832686a2e31b79bd575b