### PR TITLE
Use reserve facts when LLM cache unavailable

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -194,7 +194,7 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 if current["type"] == "country_to_capital"
                 else current["country"]
             )
-            fact = await get_random_fact(subject)
+            fact = await get_random_fact(subject, reserve_subject=current["country"])
             text = f"✅ Верно\n{current['country']}"
             if current["type"] == "country_to_capital":
                 text += f"\nСтолица: {current['capital']}"


### PR DESCRIPTION
## Summary
- Prefix all fact messages with "Интересный факт" and use reserve file on LLM failure
- Pass country name to fallback so capital questions still get country facts
- Extend tests for new behaviour and prefix

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c563d9f154832681bfa4d83ab28024