### PR TITLE
feat: make facts preload optional at startup

### DIFF
--- a/app.py
+++ b/app.py
@@ -23,6 +23,11 @@ PUBLIC_URL = os.getenv("PUBLIC_URL", "")         # https://<your-service>.onrend
 WEBHOOK_PATH = os.getenv("WEBHOOK_PATH", "/webhook")
 WEBHOOK_SECRET = os.getenv("WEBHOOK_SECRET", "secret")
 LOG_LEVEL = os.getenv("LOG_LEVEL", "INFO").upper()
+ENABLE_STARTUP_PRELOAD = os.getenv("ENABLE_STARTUP_PRELOAD", "").lower() in {
+    "1",
+    "true",
+    "yes",
+}
 
 logging.basicConfig(level=LOG_LEVEL)
 logger = logging.getLogger(__name__)
@@ -214,7 +219,10 @@ async def on_startup():
         logger.warning("PUBLIC_URL is not set; webhook check skipped")
 
     global facts_task
-    facts_task = asyncio.create_task(facts_preload_loop())
+    if ENABLE_STARTUP_PRELOAD:
+        facts_task = asyncio.create_task(facts_preload_loop())
+    else:
+        logger.info("Startup facts preload disabled")
 
     if application.job_queue:
         application.job_queue.run_repeating(


### PR DESCRIPTION
## Summary
- Add `ENABLE_STARTUP_PRELOAD` env flag to toggle initial facts preloading
- Skip `facts_preload_loop` unless the flag is enabled, relying on on-demand cache

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5a1ace09083269709cab4f5b46b96