### PR TITLE
Handle malformed facts cache entries

### DIFF
--- a/bot/facts.py
+++ b/bot/facts.py
@@ -83,6 +83,8 @@ def _load_cache() -> None:
         return
     now = datetime.now(timezone.utc)
     for subject, entry in raw.items():
+        if not isinstance(entry, dict):
+            continue
         facts = entry.get("facts")
         updated_at = entry.get("updated_at")
         if not facts or not updated_at:

--- a/scripts/seed_facts_cache.py
+++ b/scripts/seed_facts_cache.py
@@ -1,0 +1,48 @@
+#!/usr/bin/env python3
+"""Seed facts cache file for deployments.
+
+This script prepares a JSON file in the format expected by ``bot.facts``.
+It can either create an empty cache or convert ``data/facts.json``
+(which maps subject to list of facts) into the cache structure with
+``updated_at`` timestamps.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+from datetime import datetime, timezone
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+DATA_FACTS = ROOT / "data" / "facts.json"
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Prepare facts cache file")
+    parser.add_argument("path", nargs="?", default=os.getenv("FACTS_CACHE_PATH"))
+    parser.add_argument(
+        "--from-data",
+        action="store_true",
+        help="convert data/facts.json into cache format",
+    )
+    args = parser.parse_args()
+
+    if not args.path:
+        raise SystemExit("cache path must be provided or FACTS_CACHE_PATH set")
+
+    path = Path(args.path)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    if args.from_data and DATA_FACTS.exists():
+        raw = json.loads(DATA_FACTS.read_text(encoding="utf-8"))
+        now = datetime.now(timezone.utc).isoformat()
+        data = {k: {"facts": v, "updated_at": now} for k, v in raw.items()}
+    else:
+        data = {}
+
+    path.write_text(json.dumps(data, ensure_ascii=False, indent=2), encoding="utf-8")
+
+
+if __name__ == "__main__":
+    main()

--- a/tests/test_facts_cache.py
+++ b/tests/test_facts_cache.py
@@ -75,3 +75,17 @@ def test_refresh_expired_preserve_fresh(monkeypatch, tmp_path):
     assert saved["лисица"] == data["лисица"]
     assert saved["волк"]["updated_at"] != data["волк"]["updated_at"]
     assert saved["волк"]["facts"] != data["волк"]["facts"]
+
+
+def test_load_cache_ignores_non_dict(monkeypatch, tmp_path):
+    monkeypatch.setenv("OPENAI_API_KEY", "test")
+    cache_file = tmp_path / "facts.json"
+
+    now = datetime.now(timezone.utc).isoformat()
+    data = {"ok": {"facts": ["f"], "updated_at": now}, "bad": ["not", "dict"]}
+    cache_file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+
+    facts = load_facts(monkeypatch, cache_file)
+
+    assert "ok" in facts._cache
+    assert "bad" not in facts._cache


### PR DESCRIPTION
## Summary
- ignore non-dictionary entries when loading facts cache
- add `seed_facts_cache.py` to create an empty or converted cache file for deployments
- test that malformed cache entries are skipped

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c5a96fbd2083269814fc51e3605355