### PR TITLE
Add optional main menu button for continent selection

### DIFF
--- a/bot/handlers_menu.py
+++ b/bot/handlers_menu.py
@@ -34,7 +34,12 @@ async def cb_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
             text = "⏱ Игра на время: выбери континент."
         else:
             text = "📋 Учить по списку: выбери континент."
-        await q.edit_message_text(text, reply_markup=continent_kb(f"menu:{mode}"))
+        await q.edit_message_text(
+            text,
+            reply_markup=continent_kb(
+                f"menu:{mode}", include_menu=(mode == "list")
+            ),
+        )
 
     elif data.startswith("menu:cards:"):
         parts = data.split(":", 2)

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -31,14 +31,17 @@ CONTINENTS = [
 ]
 
 
-def continent_kb(prefix: str) -> InlineKeyboardMarkup:
+def continent_kb(prefix: str, include_menu: bool = False) -> InlineKeyboardMarkup:
     """Keyboard for choosing a continent.
 
     ``prefix`` should be ``menu:cards`` or ``menu:sprint`` so that callback data
     stays within the ``^menu:`` namespace while the user makes selections.
+    ``include_menu`` optionally appends a button back to the main menu.
     """
 
     rows = [[InlineKeyboardButton(c, callback_data=f"{prefix}:{c}")] for c in CONTINENTS]
+    if include_menu:
+        rows.append([InlineKeyboardButton("В меню", callback_data="menu:main")])
     return InlineKeyboardMarkup(rows)
 
 


### PR DESCRIPTION
## Summary
- add `include_menu` flag to continent keyboard to show main menu button when needed
- show return button in "Учить по списку" mode via new keyboard option

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5c375b4bc8326914c021a3a263ad2