### PR TITLE
Add dynamic country fact feature

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -120,6 +120,12 @@ def cards_answer_kb() -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(rows)
 
 
+def fact_more_kb() -> InlineKeyboardMarkup:
+    """Keyboard with a single button to request another fact."""
+    rows = [[InlineKeyboardButton("Еще один факт", callback_data="cards:more_fact")]]
+    return InlineKeyboardMarkup(rows)
+
+
 def cards_repeat_kb() -> InlineKeyboardMarkup:
     """Keyboard shown after session to repeat unknown cards."""
     rows = [

--- a/bot/state.py
+++ b/bot/state.py
@@ -96,6 +96,9 @@ class CardSession:
     queue: List[str] = field(default_factory=list)
     unknown_set: Set[str] = field(default_factory=set)
     stats: Dict[str, int] = field(default_factory=lambda: {"shown": 0, "known": 0})
+    fact_message_id: int | None = None
+    fact_subject: str | None = None
+    fact_text: str | None = None
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Add inline keyboard to request additional country facts
- Track fact message and text in card sessions
- Generate extra facts via OpenAI and handle callback to display them

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5db984ea4832682b8724db5082f2d