### PR TITLE
Refactor fact tests and add more_fact callback coverage

### DIFF
--- a/tests/test_facts.py
+++ b/tests/test_facts.py
@@ -1,18 +1,67 @@
 import sys
-from pathlib import Path
 import json
+import asyncio
+from pathlib import Path
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import os
 
 # add project root to path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 
-from bot.facts import get_static_fact
+import bot.facts  # noqa: E402
+
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token")
+
+import app  # noqa: E402
+cb_cards = app.cb_cards  # noqa: E402
+from bot.state import CardSession  # noqa: E402
 
 
-def test_get_static_fact():
-    path = Path(__file__).resolve().parents[1] / "data" / "facts_st.json"
-    data = json.loads(path.read_text(encoding="utf-8"))
-    facts = data["Канада"]
-    fact = get_static_fact("Канада")
-    prefix = "Интересный факт: "
-    assert fact.startswith(prefix)
-    assert fact[len(prefix):] in facts
+def test_get_static_fact_uses_random_fact(tmp_path, monkeypatch):
+    data = {"Канада": ["fact1", "fact2"]}
+    file = tmp_path / "facts_st.json"
+    file.write_text(json.dumps(data, ensure_ascii=False), encoding="utf-8")
+    monkeypatch.setattr(bot.facts, "_facts_path", file)
+    bot.facts._facts = json.loads(file.read_text(encoding="utf-8"))
+    monkeypatch.setattr(bot.facts.random, "choice", lambda seq: seq[1])
+    fact = bot.facts.get_static_fact("Канада")
+    assert fact == "Интересный факт: fact2"
+
+
+def test_cards_more_fact(monkeypatch):
+    async def run():
+        session = CardSession(user_id=1, queue=[])
+        session.current = {}
+        session.fact_message_id = 1
+        session.fact_subject = "Канада"
+        session.fact_text = "old"
+        context = SimpleNamespace(user_data={"card_session": session})
+
+        message = SimpleNamespace(
+            message_id=1,
+            text="Интересный факт: old\n\nНажми кнопку ниже, чтобы узнать еще один факт",
+            caption=None,
+            photo=None,
+        )
+        q = SimpleNamespace(
+            data="cards:more_fact",
+            message=message,
+            answer=AsyncMock(),
+            edit_message_text=AsyncMock(),
+            edit_message_caption=AsyncMock(),
+        )
+        update = SimpleNamespace(callback_query=q)
+
+        monkeypatch.setattr(
+            "bot.handlers_cards.generate_llm_fact", AsyncMock(return_value="new")
+        )
+
+        await cb_cards(update, context)
+
+        q.edit_message_text.assert_awaited_once_with(
+            "Интересный факт: old\nЕще один факт: new", reply_markup=None
+        )
+        assert session.fact_message_id is None
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- add tests ensuring `get_static_fact` pulls a random entry from facts JSON
- add test for `cards:more_fact` callback appending extra fact and removing button

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c5dc8c5878832691cacadd3607c82b