### PR TITLE
feat: separate additional fact with blank line

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -270,11 +270,11 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         try:
             if q.message.photo:
                 await q.edit_message_caption(
-                    caption=f"{base}\nЕще один факт: {extra}", reply_markup=None
+                    caption=f"{base}\n\nЕще один факт: {extra}", reply_markup=None
                 )
             else:
                 await q.edit_message_text(
-                    f"{base}\nЕще один факт: {extra}", reply_markup=None
+                    f"{base}\n\nЕще один факт: {extra}", reply_markup=None
                 )
         except (TelegramError, HTTPError) as e:
             logger.warning("Failed to send extra fact: %s", e)

--- a/tests/test_facts.py
+++ b/tests/test_facts.py
@@ -60,7 +60,7 @@ def test_cards_more_fact(monkeypatch):
         await cb_cards(update, context)
 
         q.edit_message_text.assert_awaited_once_with(
-            "Интересный факт: old\nЕще один факт: new", reply_markup=None
+            "Интересный факт: old\n\nЕще один факт: new", reply_markup=None
         )
         assert session.fact_message_id is None
 


### PR DESCRIPTION
## Summary
- add extra newline before follow-up fact in cards
- adjust test to match updated formatting

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c650dc85808326b439be96babdbb76