### PR TITLE
Handle list-based LLM responses in fact generator

### DIFF
--- a/bot/facts.py
+++ b/bot/facts.py
@@ -58,7 +58,18 @@ async def generate_llm_fact(country: str, exclude: str) -> str:
         else:
             kwargs["max_tokens"] = 80
         resp = await _client.chat.completions.create(**kwargs)
-        text = resp.choices[0].message.content.strip().replace("\n", " ")
+        content = resp.choices[0].message.content
+        if isinstance(content, str):
+            text = content
+        elif isinstance(content, list):
+            text = "".join(
+                seg.get("text", "")
+                for seg in content
+                if isinstance(seg, dict) and "text" in seg
+            )
+        else:
+            text = str(content)
+        text = text.strip().replace("\n", " ")
         return text[:150]
     except Exception as e:  # noqa: BLE001
         logger.warning("LLM fact generation failed: %s", e)

--- a/tests/test_facts.py
+++ b/tests/test_facts.py
@@ -65,3 +65,28 @@ def test_cards_more_fact(monkeypatch):
         assert session.fact_message_id is None
 
     asyncio.run(run())
+
+
+def test_generate_llm_fact_handles_list_content(monkeypatch):
+    async def run():
+        resp = SimpleNamespace(
+            choices=[
+                SimpleNamespace(
+                    message=SimpleNamespace(
+                        content=[
+                            {"type": "text", "text": "fact1"},
+                            {"type": "text", "text": " fact2"},
+                        ]
+                    )
+                )
+            ]
+        )
+        create = AsyncMock(return_value=resp)
+        fake_client = SimpleNamespace(
+            chat=SimpleNamespace(completions=SimpleNamespace(create=create))
+        )
+        monkeypatch.setattr(bot.facts, "_client", fake_client)
+        fact = await bot.facts.generate_llm_fact("Канада", "old")
+        assert fact == "fact1 fact2"
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- Normalize LLM chat completion content, supporting both string and list formats
- Add unit test covering list-based LLM response handling

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6551792d883268c9ecb65a73e3759