### PR TITLE
Show missing cards when finishing early

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -112,7 +112,16 @@ async def _finish_session(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
         f"знаю: {session.stats['known']}."
     )
     reply_markup = cards_finish_kb()
-    if session.unknown_set:
+    if session.stats["known"] < session.stats["shown"]:
+        if hasattr(session, "current"):
+            item = (
+                session.current["country"]
+                if session.current["type"] == "country_to_capital"
+                else session.current["capital"]
+            )
+            if item not in session.unknown_set:
+                session.unknown_set.add(item)
+                add_to_repeat(context.user_data, {item})
         unknown_lines = []
         for item in sorted(session.unknown_set):
             if item in DATA.capital_by_country:

--- a/tests/test_finish_session.py
+++ b/tests/test_finish_session.py
@@ -1,0 +1,35 @@
+import asyncio
+from types import SimpleNamespace
+
+from bot.state import CardSession
+from bot.handlers_cards import _finish_session
+from app import DATA
+
+
+class DummyBot:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, chat_id, text, reply_markup=None):
+        self.sent.append((chat_id, text, reply_markup))
+def test_finish_session_lists_unanswered():
+    country = DATA.countries()[0]
+    capital = DATA.capital_by_country[country]
+    session = CardSession(user_id=1, queue=[], stats={"shown": 1, "known": 0})
+    session.current = {
+        "type": "country_to_capital",
+        "country": country,
+        "capital": capital,
+        "prompt": "",
+        "answer": capital,
+        "options": [],
+    }
+    context = SimpleNamespace(bot=DummyBot(), user_data={"card_session": session})
+    update = SimpleNamespace(effective_chat=SimpleNamespace(id=123))
+
+    asyncio.run(_finish_session(update, context))
+
+    assert context.bot.sent, "No message was sent"
+    message_text = context.bot.sent[0][1]
+    assert "Неизвестные" in message_text
+    assert country in message_text and capital in message_text


### PR DESCRIPTION
## Summary
- Ensure flash-card sessions list unanswered cards when finishing with pending questions
- Add regression test verifying session summary includes the missed card

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c656f2691483269189fe67da5760af