### PR TITLE
Manage next-round jobs in coop mode

### DIFF
--- a/bot/state.py
+++ b/bot/state.py
@@ -3,7 +3,9 @@ from __future__ import annotations
 from dataclasses import dataclass, field
 from pathlib import Path
 from typing import Any, Dict, Iterable, List, Set
+
 import orjson
+from telegram.ext import Job
 
 
 @dataclass
@@ -128,6 +130,7 @@ class CoopSession:
     answer_options: Dict[int, str] = field(default_factory=dict)
     question_message_ids: Dict[int, int] = field(default_factory=dict)
     current_question: Dict[str, Any] | None = None
+    jobs: Dict[str, Job] = field(default_factory=dict)
 
 
 @dataclass


### PR DESCRIPTION
## Summary
- Track scheduled tasks in `CoopSession` via a new `jobs` field
- Schedule next coop round with JobQueue and save the returned job for cancellation
- Cancel and clear the pending next-round job when finishing a match

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c68381abac83269b159a20d32de75a