### PR TITLE
Validate coop rounds and difficulty selections

### DIFF
--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -249,6 +249,50 @@ async def cb_coop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     sessions = _get_sessions(context)
 
+    if action == "rounds":
+        session_id = parts[2]
+        player_id = int(parts[3])
+        rounds = int(parts[4])
+        session = sessions.get(session_id)
+        if not session:
+            await q.answer()
+            return
+        if update.effective_user.id not in session.players:
+            await q.answer("Не вы участвуете", show_alert=True)
+            return
+        if player_id != update.effective_user.id:
+            await q.answer("Не ваша кнопка", show_alert=True)
+            return
+        session.total_rounds = rounds
+        await q.answer()
+        try:
+            await q.edit_message_reply_markup(None)
+        except (TelegramError, HTTPError) as e:
+            logger.warning("Failed to clear rounds keyboard: %s", e)
+        return
+
+    if action == "diff":
+        session_id = parts[2]
+        player_id = int(parts[3])
+        difficulty = parts[4]
+        session = sessions.get(session_id)
+        if not session:
+            await q.answer()
+            return
+        if update.effective_user.id not in session.players:
+            await q.answer("Не вы участвуете", show_alert=True)
+            return
+        if player_id != update.effective_user.id:
+            await q.answer("Не ваша кнопка", show_alert=True)
+            return
+        session.difficulty = difficulty
+        await q.answer()
+        try:
+            await q.edit_message_reply_markup(None)
+        except (TelegramError, HTTPError) as e:
+            logger.warning("Failed to clear difficulty keyboard: %s", e)
+        return
+
     if action == "cont":
         session_id = parts[2]
         continent = parts[3]

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -201,24 +201,49 @@ def coop_join_kb(session_id: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(rows)
 
 
-def coop_rounds_kb(session_id: str) -> InlineKeyboardMarkup:
+def coop_rounds_kb(session_id: str, player_id: int) -> InlineKeyboardMarkup:
     """Keyboard to select number of rounds."""
 
     rows = [
-        [InlineKeyboardButton("5", callback_data=f"coop:rounds:{session_id}:5")],
-        [InlineKeyboardButton("10", callback_data=f"coop:rounds:{session_id}:10")],
-        [InlineKeyboardButton("15", callback_data=f"coop:rounds:{session_id}:15")],
+        [
+            InlineKeyboardButton(
+                "5", callback_data=f"coop:rounds:{session_id}:{player_id}:5"
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "10", callback_data=f"coop:rounds:{session_id}:{player_id}:10"
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "15", callback_data=f"coop:rounds:{session_id}:{player_id}:15"
+            )
+        ],
     ]
     return InlineKeyboardMarkup(rows)
 
 
-def coop_difficulty_kb(session_id: str) -> InlineKeyboardMarkup:
+def coop_difficulty_kb(session_id: str, player_id: int) -> InlineKeyboardMarkup:
     """Keyboard to select bot difficulty."""
 
     rows = [
-        [InlineKeyboardButton("🟢 Лёгкий", callback_data=f"coop:diff:{session_id}:easy")],
-        [InlineKeyboardButton("🟡 Средний", callback_data=f"coop:diff:{session_id}:medium")],
-        [InlineKeyboardButton("🔴 Сложный", callback_data=f"coop:diff:{session_id}:hard")],
+        [
+            InlineKeyboardButton(
+                "🟢 Лёгкий", callback_data=f"coop:diff:{session_id}:{player_id}:easy"
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "🟡 Средний",
+                callback_data=f"coop:diff:{session_id}:{player_id}:medium",
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "🔴 Сложный", callback_data=f"coop:diff:{session_id}:{player_id}:hard"
+            )
+        ],
     ]
     return InlineKeyboardMarkup(rows)
 


### PR DESCRIPTION
## Summary
- Include player id in cooperative rounds and difficulty keyboards for stricter validation
- Reject rounds and difficulty callbacks from users outside of the current session

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c684acac248326886b3445a9c66b71