### PR TITLE
Add menu button for cooperative mode

### DIFF
--- a/bot/handlers_menu.py
+++ b/bot/handlers_menu.py
@@ -7,7 +7,13 @@ from telegram.ext import ContextTypes
 
 from app import DATA
 from .state import CardSession
-from .keyboards import main_menu_kb, continent_kb, sprint_start_kb, list_result_kb
+from .keyboards import (
+    main_menu_kb,
+    continent_kb,
+    sprint_start_kb,
+    list_result_kb,
+    back_to_menu_kb,
+)
 from .flags import get_country_flag
 
 WELCOME = (
@@ -105,7 +111,7 @@ async def cb_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     elif data == "menu:coop":
         await q.edit_message_text(
             "🤝 Дуэт против Бота: запускай в групповом чате командой /coop_capitals",
-            reply_markup=None,
+            reply_markup=back_to_menu_kb(),
         )
 
     elif data == "menu:main":

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -45,6 +45,13 @@ def continent_kb(prefix: str, include_menu: bool = False) -> InlineKeyboardMarku
     return InlineKeyboardMarkup(rows)
 
 
+def back_to_menu_kb() -> InlineKeyboardMarkup:
+    """Keyboard with a single button that returns to the main menu."""
+
+    rows = [[InlineKeyboardButton("В меню", callback_data="menu:main")]]
+    return InlineKeyboardMarkup(rows)
+
+
 def direction_kb(prefix: str, continent: str) -> InlineKeyboardMarkup:
     """Keyboard for choosing question direction.
 


### PR DESCRIPTION
## Summary
- add keyboard for returning to the main menu
- show the button when opening cooperative mode instructions

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c68675ad008326b97071afd63f7cf2