### PR TITLE
style: bold wrong answers

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -258,7 +258,11 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             try:
                 await context.bot.send_message(
                     q.message.chat_id,
-                    f"❌ Неверно.\nПравильный ответ:\n{current['answer']}",
+                    (
+                        "❌ <b>Неверно</b>."
+                        f"\n\nПравильный ответ:\n<b>{current['answer']}</b>"
+                    ),
+                    parse_mode="HTML",
                 )
             except (TelegramError, HTTPError) as e:
                 logger.warning("Failed to send card feedback: %s", e)

--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -364,14 +364,14 @@ async def cb_coop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         f"Игрок 1 → {session.answer_options[session.players[0]]} {'✅' if session.answers[session.players[0]] else '❌'}\n"
         f"Игрок 2 → {session.answer_options[session.players[1]]} {'✅' if session.answers[session.players[1]] else '❌'}\n"
         f"Бот-соперник → {'✅' if bot_correct else '❌'}\n"
-        f"Правильный ответ: {correct_display}\n"
+        f"Правильный ответ: <b>{correct_display}</b>\n"
         f"Счёт: Команда {session.team_score} — Бот {session.bot_score} (Раунд {session.current_round}/{session.total_rounds})"
     )
 
     for pid in session.players:
         chat_id = session.player_chats[pid]
         try:
-            await context.bot.send_message(chat_id, result_text)
+            await context.bot.send_message(chat_id, result_text, parse_mode="HTML")
         except (TelegramError, HTTPError) as e:
             logger.warning("Failed to send coop round result: %s", e)
 

--- a/bot/handlers_sprint.py
+++ b/bot/handlers_sprint.py
@@ -223,7 +223,11 @@ async def cb_sprint(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             try:
                 await context.bot.send_message(
                     q.message.chat_id,
-                    f"❌ Неверно.\nПравильный ответ:\n{session.current['correct']}",
+                    (
+                        "❌ <b>Неверно</b>."
+                        f"\n\nПравильный ответ:\n<b>{session.current['correct']}</b>"
+                    ),
+                    parse_mode="HTML",
                 )
             except (TelegramError, HTTPError) as e:
                 logger.warning("Failed to send sprint wrong message: %s", e)


### PR DESCRIPTION
## Summary
- Bold "Неверно" with spacing in card and sprint feedback
- Highlight correct answers in coop round results

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6871e7f7c83268c415142396e4663