### PR TITLE
Add player name capture and invitation flow for coop mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -9,8 +9,13 @@ from dotenv import load_dotenv
 
 from telegram import Update
 from telegram.ext import (
-    Application, ApplicationBuilder, ContextTypes,
-    CommandHandler, CallbackQueryHandler
+    Application,
+    ApplicationBuilder,
+    ContextTypes,
+    CommandHandler,
+    CallbackQueryHandler,
+    MessageHandler,
+    filters,
 )
 
 from bot.utils import tg_call
@@ -68,6 +73,7 @@ from bot.handlers_coop import (
     cmd_coop_join,
     cmd_coop_cancel,
     cmd_coop_test,
+    msg_coop,
 )
 from bot.handlers_stats import cmd_stats
 
@@ -83,6 +89,9 @@ application.add_handler(CommandHandler("coop_join", cmd_coop_join))
 application.add_handler(CommandHandler("coop_cancel", cmd_coop_cancel))
 application.add_handler(CommandHandler("coop_test", cmd_coop_test))
 application.add_handler(CommandHandler("stats", cmd_stats))
+application.add_handler(
+    MessageHandler((filters.TEXT & ~filters.COMMAND) | filters.CONTACT, msg_coop)
+)
 
 
 async def check_webhook(context: ContextTypes.DEFAULT_TYPE) -> None:

--- a/bot/handlers_menu.py
+++ b/bot/handlers_menu.py
@@ -22,6 +22,14 @@ WELCOME = (
 )
 
 async def cmd_start(update: Update, context: ContextTypes.DEFAULT_TYPE):
+    if context.args and context.args[0].startswith("coop_"):
+        from .handlers_coop import cmd_coop_join
+
+        session_id = context.args[0][5:]
+        context.args = [session_id]
+        await cmd_coop_join(update, context)
+        return
+
     chat_id = update.effective_chat.id
     await context.bot.send_message(chat_id, WELCOME, reply_markup=main_menu_kb())
 

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -1,7 +1,12 @@
 """Inline keyboards used across the bot menus."""
 
 from textwrap import shorten
-from telegram import InlineKeyboardButton, InlineKeyboardMarkup
+from telegram import (
+    InlineKeyboardButton,
+    InlineKeyboardMarkup,
+    KeyboardButton,
+    ReplyKeyboardMarkup,
+)
 
 # Text longer than this will be placed on its own row instead of pairing.
 LONG_OPTION = 15
@@ -206,6 +211,16 @@ def coop_join_kb(session_id: str) -> InlineKeyboardMarkup:
 
     rows = [[InlineKeyboardButton("🙋 Участвовать", callback_data=f"coop:join:{session_id}")]]
     return InlineKeyboardMarkup(rows)
+
+
+def coop_invite_kb() -> ReplyKeyboardMarkup:
+    """Keyboard for inviting the second player."""
+
+    rows = [
+        [KeyboardButton("Пригласить из контактов", request_contact=True)],
+        [KeyboardButton("Создать ссылку")],
+    ]
+    return ReplyKeyboardMarkup(rows, resize_keyboard=True, one_time_keyboard=True)
 
 
 def coop_rounds_kb(session_id: str, player_id: int) -> InlineKeyboardMarkup:

--- a/bot/state.py
+++ b/bot/state.py
@@ -119,6 +119,7 @@ class CoopSession:
     session_id: str
     players: List[int] = field(default_factory=list)
     player_chats: Dict[int, int] = field(default_factory=dict)
+    player_names: Dict[int, str] = field(default_factory=dict)
     continent_filter: str | None = None
     mode: str = "mixed"
     difficulty: str = "easy"


### PR DESCRIPTION
## Summary
- extend `CoopSession` with `player_names`
- request player names and invite second player via contact or link
- handle deep-link joins and register message handler for coop flow

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c68b5379348326a21cb102cd55ce0d