### PR TITLE
Prompt players for rounds and difficulty before starting coop match

### DIFF
--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -16,7 +16,7 @@ from httpx import HTTPError
 from app import DATA
 from .state import CoopSession
 from .questions import pick_question
-from .keyboards import coop_answer_kb, coop_continent_kb
+from .keyboards import coop_answer_kb, coop_rounds_kb, coop_difficulty_kb
 
 
 ADMIN_ID = int(os.getenv("ADMIN_ID", "0"))
@@ -175,25 +175,27 @@ async def cmd_coop_join(update: Update, context: ContextTypes.DEFAULT_TYPE) -> N
     session.players.append(user_id)
     session.player_chats[user_id] = update.effective_chat.id
 
-    # Prompt both players to choose a continent before starting the match
+    # Prompt both players to choose number of rounds
     try:
-        await update.message.reply_text(
-            "Вы присоединились. Выберите континент.",
-            reply_markup=coop_continent_kb(session_id),
+        msg = await update.message.reply_text(
+            "Вы присоединились. Выберите количество раундов.",
+            reply_markup=coop_rounds_kb(session_id, user_id),
         )
+        session.rounds_message_ids[user_id] = msg.message_id
     except (TelegramError, HTTPError) as e:
-        logger.warning("Failed to send continent keyboard to second player: %s", e)
+        logger.warning("Failed to send rounds keyboard to second player: %s", e)
 
     first_player = session.players[0]
     first_chat = session.player_chats[first_player]
     try:
-        await context.bot.send_message(
+        msg = await context.bot.send_message(
             first_chat,
-            "Второй игрок присоединился. Выберите континент.",
-            reply_markup=coop_continent_kb(session_id),
+            "Второй игрок присоединился. Выберите количество раундов.",
+            reply_markup=coop_rounds_kb(session_id, first_player),
         )
+        session.rounds_message_ids[first_player] = msg.message_id
     except (TelegramError, HTTPError) as e:
-        logger.warning("Failed to send continent keyboard to first player: %s", e)
+        logger.warning("Failed to send rounds keyboard to first player: %s", e)
 
 
 async def cmd_coop_cancel(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
@@ -265,10 +267,26 @@ async def cb_coop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             return
         session.total_rounds = rounds
         await q.answer()
-        try:
-            await q.edit_message_reply_markup(None)
-        except (TelegramError, HTTPError) as e:
-            logger.warning("Failed to clear rounds keyboard: %s", e)
+        for pid, msg_id in session.rounds_message_ids.items():
+            chat_id = session.player_chats[pid]
+            try:
+                await context.bot.edit_message_reply_markup(
+                    chat_id, msg_id, reply_markup=None
+                )
+            except (TelegramError, HTTPError) as e:
+                logger.warning("Failed to clear rounds keyboard: %s", e)
+        session.rounds_message_ids.clear()
+        for pid in session.players:
+            chat_id = session.player_chats[pid]
+            try:
+                msg = await context.bot.send_message(
+                    chat_id,
+                    "Выберите сложность соперника.",
+                    reply_markup=coop_difficulty_kb(session_id, pid),
+                )
+                session.difficulty_message_ids[pid] = msg.message_id
+            except (TelegramError, HTTPError) as e:
+                logger.warning("Failed to send difficulty keyboard: %s", e)
         return
 
     if action == "diff":
@@ -287,28 +305,15 @@ async def cb_coop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             return
         session.difficulty = difficulty
         await q.answer()
-        try:
-            await q.edit_message_reply_markup(None)
-        except (TelegramError, HTTPError) as e:
-            logger.warning("Failed to clear difficulty keyboard: %s", e)
-        return
-
-    if action == "cont":
-        session_id = parts[2]
-        continent = parts[3]
-        session = sessions.get(session_id)
-        if not session or update.effective_user.id not in session.players:
-            await q.answer()
-            return
-        if session.continent_filter is not None:
-            await q.answer("Континент уже выбран", show_alert=True)
-            return
-        session.continent_filter = None if continent == "Весь мир" else continent
-        await q.answer()
-        try:
-            await q.edit_message_reply_markup(None)
-        except (TelegramError, HTTPError) as e:
-            logger.warning("Failed to clear continent keyboard: %s", e)
+        for pid, msg_id in session.difficulty_message_ids.items():
+            chat_id = session.player_chats[pid]
+            try:
+                await context.bot.edit_message_reply_markup(
+                    chat_id, msg_id, reply_markup=None
+                )
+            except (TelegramError, HTTPError) as e:
+                logger.warning("Failed to clear difficulty keyboard: %s", e)
+        session.difficulty_message_ids.clear()
         session.current_round = 1
         await _start_round(context, session)
         return

--- a/bot/state.py
+++ b/bot/state.py
@@ -129,6 +129,8 @@ class CoopSession:
     answers: Dict[int, bool] = field(default_factory=dict)
     answer_options: Dict[int, str] = field(default_factory=dict)
     question_message_ids: Dict[int, int] = field(default_factory=dict)
+    rounds_message_ids: Dict[int, int] = field(default_factory=dict)
+    difficulty_message_ids: Dict[int, int] = field(default_factory=dict)
     current_question: Dict[str, Any] | None = None
     jobs: Dict[str, Job] = field(default_factory=dict)
 


### PR DESCRIPTION
## Summary
- Ask both players to choose match length when the second player joins
- After selecting rounds, prompt both players to choose bot difficulty
- Begin cooperative match only after difficulty is chosen and track config messages in session state

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c69c5f2794832684381582dc789015