### PR TITLE
Add rounds and difficulty prompts to coop mode

### DIFF
--- a/bot/state.py
+++ b/bot/state.py
@@ -122,8 +122,8 @@ class CoopSession:
     player_names: Dict[int, str] = field(default_factory=dict)
     continent_filter: str | None = None
     mode: str = "mixed"
-    difficulty: str = "easy"
-    total_rounds: int = 5
+    difficulty: str = ""
+    total_rounds: int = 0
     current_round: int = 0
     team_score: int = 0
     bot_score: int = 0


### PR DESCRIPTION
## Summary
- Ask both cooperative players to choose number of rounds and bot difficulty after joining
- Start cooperative match only when rounds and difficulty are selected

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c69ef643e88326bc1af513bc01d377