### PR TITLE
feat: add test mode to main menu

### DIFF
--- a/bot/handlers_menu.py
+++ b/bot/handlers_menu.py
@@ -40,14 +40,19 @@ async def cb_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     await q.answer()
     data = q.data
 
-    if data in {"menu:cards", "menu:sprint", "menu:list"}:
+    if data == "menu:void":
+        return
+
+    if data in {"menu:cards", "menu:sprint", "menu:list", "menu:test"}:
         mode = data.split(":")[1]
         if mode == "cards":
             text = "📘 Флэш-карточки: выбери континент."
         elif mode == "sprint":
             text = "⏱ Игра на время: выбери континент."
+        elif mode == "test":
+            text = "📝 Тест: выбери континент."
         else:
-            text = "📋 Учить по списку: выбери континент."
+            text = "📋 Учить по спискам: выбери континент."
         await q.edit_message_text(
             text,
             reply_markup=continent_kb(

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -15,12 +15,16 @@ SPACER = "────────────"
 
 
 def main_menu_kb() -> InlineKeyboardMarkup:
-    """Top-level menu with four learning modes."""
+    """Top-level menu with learning modes and games."""
+
     rows = [
-        [InlineKeyboardButton("📘 Флэш-карточки", callback_data="menu:cards")],
-        [InlineKeyboardButton("⏱ Игра на время", callback_data="menu:sprint")],
-        [InlineKeyboardButton("🤝 Дуэт против Бота", callback_data="menu:coop")],
-        [InlineKeyboardButton("📋 Учить по списку стран", callback_data="menu:list")],
+        [InlineKeyboardButton("ОБУЧЕНИЕ", callback_data="menu:void")],
+        [InlineKeyboardButton("📘 Флэш-карточки", callback_data="menu:cards")],
+        [InlineKeyboardButton("📋 Учить по спискам", callback_data="menu:list")],
+        [InlineKeyboardButton("📝 Тест", callback_data="menu:test")],
+        [InlineKeyboardButton("ИГРЫ", callback_data="menu:void")],
+        [InlineKeyboardButton("⏱ Игра на время", callback_data="menu:sprint")],
+        [InlineKeyboardButton("🤝 Дуэт против Бота", callback_data="menu:coop")],
     ]
     return InlineKeyboardMarkup(rows)
 


### PR DESCRIPTION
## Summary
- restructure top-level menu with learning and game sections
- handle menu:void and add placeholder for test mode selection

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6ad1b60d4832690009c62ba693114