### PR TITLE
Add test mode handler and keyboard

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,6 +67,7 @@ DATA = load_data()
 from bot.handlers_menu import cmd_start, cb_menu
 from bot.handlers_cards import cb_cards
 from bot.handlers_sprint import cb_sprint
+from bot.handlers_test import cb_test
 from bot.handlers_coop import (
     cb_coop,
     cmd_coop_capitals,
@@ -83,6 +84,7 @@ application.add_handler(CommandHandler("start", cmd_start))
 application.add_handler(CallbackQueryHandler(cb_menu, pattern="^menu:"))
 application.add_handler(CallbackQueryHandler(cb_cards, pattern="^cards:"))
 application.add_handler(CallbackQueryHandler(cb_sprint, pattern="^sprint:"))
+application.add_handler(CallbackQueryHandler(cb_test, pattern="^test:"))
 application.add_handler(CallbackQueryHandler(cb_coop, pattern="^coop:"))
 application.add_handler(CommandHandler("coop_capitals", cmd_coop_capitals))
 application.add_handler(CommandHandler("coop_join", cmd_coop_join))

--- a/bot/handlers_menu.py
+++ b/bot/handlers_menu.py
@@ -13,6 +13,7 @@ from .keyboards import (
     sprint_start_kb,
     list_result_kb,
     back_to_menu_kb,
+    test_start_kb,
 )
 from .flags import get_country_flag
 
@@ -43,14 +44,12 @@ async def cb_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
     if data == "menu:void":
         return
 
-    if data in {"menu:cards", "menu:sprint", "menu:list", "menu:test"}:
+    if data in {"menu:cards", "menu:sprint", "menu:list"}:
         mode = data.split(":")[1]
         if mode == "cards":
             text = "📘 Флэш-карточки: выбери континент."
         elif mode == "sprint":
             text = "⏱ Игра на время: выбери континент."
-        elif mode == "test":
-            text = "📝 Тест: выбери континент."
         else:
             text = "📋 Учить по спискам: выбери континент."
         await q.edit_message_text(
@@ -58,6 +57,10 @@ async def cb_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
             reply_markup=continent_kb(
                 f"menu:{mode}", include_menu=(mode == "list")
             ),
+        )
+    elif data == "menu:test":
+        await q.edit_message_text(
+            "📝 Тест: выбери режим.", reply_markup=test_start_kb()
         )
 
     elif data.startswith("menu:cards:"):

--- a/bot/handlers_test.py
+++ b/bot/handlers_test.py
@@ -1,0 +1,215 @@
+import asyncio
+import random
+import logging
+
+from telegram import Update
+from telegram.error import TelegramError, BadRequest
+from telegram.ext import ContextTypes
+from httpx import HTTPError
+
+# ``DATA`` is loaded in ``app`` which requires TELEGRAM_BOT_TOKEN to be set.
+# During unit tests this environment variable may be missing, so fall back to
+# ``None`` to avoid import-time errors.
+try:  # pragma: no cover - best effort for missing token during tests
+    from app import DATA
+except RuntimeError:  # pragma: no cover - token not set
+    DATA = None  # type: ignore
+from .state import TestSession
+from .keyboards import (
+    cards_kb,
+    cards_answer_kb,
+    back_to_menu_kb,
+    continent_kb,
+)
+from .questions import make_card_question
+from .flags import get_country_flag
+
+logger = logging.getLogger(__name__)
+
+__all__ = ("cb_test",)
+__test__ = False
+
+
+async def _next_question(
+    update: Update, context: ContextTypes.DEFAULT_TYPE, replace_message: bool = True
+) -> None:
+    """Send the next test question or finish if queue is empty."""
+
+    session: TestSession = context.user_data["test_session"]
+    if not session.queue:
+        await _finish_session(update, context)
+        return
+
+    country = session.queue.pop(0)
+    direction = random.choice(["country_to_capital", "capital_to_country"])
+    item = country if direction == "country_to_capital" else DATA.capital_by_country[country]
+    question = make_card_question(DATA, item, direction)
+    session.current = question
+    session.stats["total"] += 1
+
+    logger.debug(
+        "Generated test question for user %s: %s -> %s",
+        session.user_id,
+        question["prompt"],
+        question["answer"],
+    )
+
+    if update.callback_query and replace_message:
+        q = update.callback_query
+        try:
+            await q.edit_message_text(
+                question["prompt"],
+                reply_markup=cards_kb(question["options"]),
+                parse_mode="HTML",
+            )
+        except (TelegramError, HTTPError) as e:
+            logger.warning("Failed to send test question: %s", e)
+            return
+    else:
+        chat_id = update.effective_chat.id
+        try:
+            await context.bot.send_message(
+                chat_id,
+                question["prompt"],
+                reply_markup=cards_kb(question["options"]),
+                parse_mode="HTML",
+            )
+        except (TelegramError, HTTPError) as e:
+            logger.warning("Failed to send test question: %s", e)
+            return
+
+
+async def _finish_session(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Output final stats and unknown pairs."""
+
+    session: TestSession | None = context.user_data.get("test_session")
+    if not session:
+        return
+
+    text = f"{session.stats['correct']} правильных из {session.stats['total']}"
+    if session.unknown_set:
+        lines = []
+        for country in sorted(session.unknown_set):
+            capital = DATA.capital_by_country.get(country, "")
+            flag = get_country_flag(country)
+            lines.append(f"{flag} {country} — {capital}")
+        text += "\n\nОшибки или пропуски:\n" + "\n".join(lines)
+    chat_id = update.effective_chat.id
+    try:
+        await context.bot.send_message(chat_id, text, reply_markup=back_to_menu_kb())
+    except (TelegramError, HTTPError) as e:
+        logger.warning("Failed to send test results: %s", e)
+    context.user_data.pop("test_session", None)
+
+
+async def cb_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle all ``^test:`` callbacks."""
+
+    q = update.callback_query
+    parts = q.data.split(":")
+
+    if parts == ["test", "continent"]:
+        await q.answer()
+        await q.edit_message_text(
+            "📝 Тест: выбери континент.",
+            reply_markup=continent_kb("test", include_menu=True, include_world=False),
+        )
+        return
+
+    if parts == ["test", "random30"]:
+        await q.answer()
+        countries = DATA.countries()
+        queue = random.sample(countries, k=min(30, len(countries)))
+        session = TestSession(user_id=update.effective_user.id, queue=queue)
+        context.user_data["test_session"] = session
+        await _next_question(update, context)
+        return
+
+    if len(parts) == 2 and parts[0] == "test" and parts[1] not in {
+        "opt",
+        "show",
+        "skip",
+        "next",
+        "finish",
+    }:
+        await q.answer()
+        continent = parts[1]
+        queue = DATA.countries(continent)
+        random.shuffle(queue)
+        session = TestSession(user_id=update.effective_user.id, queue=queue)
+        context.user_data["test_session"] = session
+        await _next_question(update, context)
+        return
+
+    session: TestSession | None = context.user_data.get("test_session")
+    if not session or not hasattr(session, "current"):
+        await q.answer()
+        try:
+            await q.edit_message_text("Сессия не найдена", reply_markup=back_to_menu_kb())
+        except (TelegramError, HTTPError) as e:
+            logger.warning("Failed to notify missing session: %s", e)
+        return
+
+    current = session.current
+    if parts[1] == "opt":
+        await q.answer()
+        index = int(parts[2])
+        selected = current["options"][index]
+        try:
+            await q.edit_message_reply_markup(None)
+        except (TelegramError, HTTPError) as e:
+            logger.warning("Failed to clear test buttons: %s", e)
+        if selected == current["answer"]:
+            session.stats["correct"] += 1
+            text = "✅ Верно"
+            if current["type"] == "country_to_capital":
+                text += f"\n{current['country']}\nСтолица: {current['capital']}"
+            else:
+                text += f"\n{current['country']}"
+        else:
+            session.unknown_set.add(current["country"])
+            text = (
+                "❌ <b>Неверно</b>."
+                f"\n\nПравильный ответ:\n<b>{current['answer']}</b>"
+            )
+        try:
+            await context.bot.send_message(q.message.chat_id, text, parse_mode="HTML")
+        except (TelegramError, HTTPError) as e:
+            logger.warning("Failed to send test feedback: %s", e)
+        await asyncio.sleep(2)
+        await _next_question(update, context, replace_message=False)
+        return
+
+    action = parts[1]
+    if action == "show":
+        await q.answer()
+        session.unknown_set.add(current["country"])
+        try:
+            await q.edit_message_text(
+                f"{current['prompt']}\n\n<b>Ответ: {current['answer']}</b>",
+                parse_mode="HTML",
+                reply_markup=cards_answer_kb(),
+            )
+        except BadRequest:
+            logger.debug("Duplicate show answer for user %s", session.user_id)
+        except (TelegramError, HTTPError) as e:
+            logger.warning("Failed to show test answer: %s", e)
+        return
+
+    if action == "next":
+        await q.answer()
+        await _next_question(update, context)
+        return
+
+    if action == "skip":
+        await q.answer()
+        session.unknown_set.add(current["country"])
+        await _next_question(update, context)
+        return
+
+    if action == "finish":
+        await q.answer()
+        await _finish_session(update, context)
+        return
+
+    await q.answer()

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -40,17 +40,32 @@ CONTINENTS = [
 ]
 
 
-def continent_kb(prefix: str, include_menu: bool = False) -> InlineKeyboardMarkup:
+def continent_kb(
+    prefix: str, include_menu: bool = False, include_world: bool = True
+) -> InlineKeyboardMarkup:
     """Keyboard for choosing a continent.
 
     ``prefix`` should be ``menu:cards`` or ``menu:sprint`` so that callback data
     stays within the ``^menu:`` namespace while the user makes selections.
-    ``include_menu`` optionally appends a button back to the main menu.
+    ``include_menu`` optionally appends a button back to the main menu. Set
+    ``include_world`` to ``False`` to hide the "Весь мир" option.
     """
 
-    rows = [[InlineKeyboardButton(c, callback_data=f"{prefix}:{c}")] for c in CONTINENTS]
+    continents = CONTINENTS if include_world else [c for c in CONTINENTS if c != "Весь мир"]
+    rows = [[InlineKeyboardButton(c, callback_data=f"{prefix}:{c}")] for c in continents]
     if include_menu:
         rows.append([InlineKeyboardButton("В меню", callback_data="menu:main")])
+    return InlineKeyboardMarkup(rows)
+
+
+def test_start_kb() -> InlineKeyboardMarkup:
+    """Keyboard for starting the test mode."""
+
+    rows = [
+        [InlineKeyboardButton("Тестировать континент", callback_data="test:continent")],
+        [InlineKeyboardButton("Тестировать 30 случайных", callback_data="test:random30")],
+        [InlineKeyboardButton("В меню", callback_data="menu:main")],
+    ]
     return InlineKeyboardMarkup(rows)
 
 

--- a/bot/state.py
+++ b/bot/state.py
@@ -104,6 +104,14 @@ class CardSession:
 
 
 @dataclass
+class TestSession:
+    user_id: int
+    queue: List[str] = field(default_factory=list)
+    unknown_set: Set[str] = field(default_factory=set)
+    stats: Dict[str, int] = field(default_factory=lambda: {"total": 0, "correct": 0})
+
+
+@dataclass
 class SprintSession:
     user_id: int
     duration_sec: int = 60


### PR DESCRIPTION
## Summary
- add start keyboard and continent selector for new test mode
- implement TestSession dataclass and handlers for testing flow
- register test callbacks and update menu to launch tests

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6aebb0d9083269c03a8c305c3fe36