### PR TITLE
Handle per-item direction in mixed cards

### DIFF
--- a/bot/handlers_menu.py
+++ b/bot/handlers_menu.py
@@ -68,7 +68,11 @@ async def cb_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
         continent = parts[2]
         context.user_data["continent"] = continent
         continent_filter = None if continent == "Весь мир" else continent
-        queue = DATA.items(continent_filter, "mixed")
+        countries = DATA.countries(continent_filter)
+        queue = [
+            (c, random.choice(["country_to_capital", "capital_to_country"]))
+            for c in countries
+        ]
         random.shuffle(queue)
         session = CardSession(
             user_id=update.effective_user.id,


### PR DESCRIPTION
## Summary
- Queue only countries for mixed flash-card sessions and assign a random direction per country
- Use stored direction when generating each card and remove requeue on skip

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6b144c4c48326a6e677465b44f8b4