### PR TITLE
feat: sequential coop turns

### DIFF
--- a/bot/state.py
+++ b/bot/state.py
@@ -135,6 +135,8 @@ class CoopSession:
     current_round: int = 0
     team_score: int = 0
     bot_score: int = 0
+    current_turn_index: int = 0
+    bot_think_delay: float = 2.0
     answers: Dict[int, bool] = field(default_factory=dict)
     answer_options: Dict[int, str] = field(default_factory=dict)
     question_message_ids: Dict[int, int] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- add current_turn_index and bot_think_delay to CoopSession
- send questions one player at a time and enforce turn order in coop mode
- schedule delayed bot moves and keep team vs bot scores

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6be44d7f483269a5e9b045ac84232