### PR TITLE
Support custom prefixes for card keyboards and test mode

### DIFF
--- a/bot/handlers_test.py
+++ b/bot/handlers_test.py
@@ -59,7 +59,7 @@ async def _next_question(
         try:
             await q.edit_message_text(
                 question["prompt"],
-                reply_markup=cards_kb(question["options"]),
+                reply_markup=cards_kb(question["options"], prefix="test"),
                 parse_mode="HTML",
             )
         except (TelegramError, HTTPError) as e:
@@ -71,7 +71,7 @@ async def _next_question(
             await context.bot.send_message(
                 chat_id,
                 question["prompt"],
-                reply_markup=cards_kb(question["options"]),
+                reply_markup=cards_kb(question["options"], prefix="test"),
                 parse_mode="HTML",
             )
         except (TelegramError, HTTPError) as e:
@@ -107,6 +107,10 @@ async def cb_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
 
     q = update.callback_query
     parts = q.data.split(":")
+
+    if parts == ["test", "void"]:
+        await q.answer()
+        return
 
     if parts == ["test", "continent"]:
         await q.answer()
@@ -188,7 +192,7 @@ async def cb_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             await q.edit_message_text(
                 f"{current['prompt']}\n\n<b>Ответ: {current['answer']}</b>",
                 parse_mode="HTML",
-                reply_markup=cards_answer_kb(),
+                reply_markup=cards_answer_kb(prefix="test"),
             )
         except BadRequest:
             logger.debug("Duplicate show answer for user %s", session.user_id)

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -130,14 +130,19 @@ def sprint_start_kb(continent: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(rows)
 
 
-def cards_kb(options: list[str]) -> InlineKeyboardMarkup:
-    """Keyboard for flash-card questions with answer options."""
+def cards_kb(options: list[str], prefix: str = "cards") -> InlineKeyboardMarkup:
+    """Keyboard for flash-card questions with answer options.
+
+    ``prefix`` determines the callback namespace.  By default the regular
+    ``cards`` prefix is used, but alternative prefixes (e.g. ``test``) can be
+    supplied for other handlers.
+    """
 
     rows: list[list[InlineKeyboardButton]] = []
     buffer: list[InlineKeyboardButton] = []
     for i, opt in enumerate(options):
         text = shorten(opt, width=40, placeholder="")
-        btn = InlineKeyboardButton(text, callback_data=f"cards:opt:{i}")
+        btn = InlineKeyboardButton(text, callback_data=f"{prefix}:opt:{i}")
         if len(text) > LONG_OPTION:
             if buffer:
                 rows.append(buffer)
@@ -152,18 +157,21 @@ def cards_kb(options: list[str]) -> InlineKeyboardMarkup:
         rows.append(buffer)
     # spacer row to visually separate options from action buttons
 
-    rows.append([InlineKeyboardButton(SPACER, callback_data="cards:void")])
-    rows.append([InlineKeyboardButton("Показать ответ", callback_data="cards:show")])
-    rows.append([InlineKeyboardButton("Пропустить", callback_data="cards:skip")])
-    rows.append([InlineKeyboardButton("Завершить", callback_data="cards:finish")])
+    rows.append([InlineKeyboardButton(SPACER, callback_data=f"{prefix}:void")])
+    rows.append([InlineKeyboardButton("Показать ответ", callback_data=f"{prefix}:show")])
+    rows.append([InlineKeyboardButton("Пропустить", callback_data=f"{prefix}:skip")])
+    rows.append([InlineKeyboardButton("Завершить", callback_data=f"{prefix}:finish")])
     return InlineKeyboardMarkup(rows)
 
 
-def cards_answer_kb() -> InlineKeyboardMarkup:
-    """Keyboard shown after revealing the answer."""
+def cards_answer_kb(prefix: str = "cards") -> InlineKeyboardMarkup:
+    """Keyboard shown after revealing the answer.
+
+    ``prefix`` allows reuse of this keyboard in different callback namespaces.
+    """
     rows = [
-        [InlineKeyboardButton("Продолжить", callback_data="cards:next")],
-        [InlineKeyboardButton("Завершить", callback_data="cards:finish")],
+        [InlineKeyboardButton("Продолжить", callback_data=f"{prefix}:next")],
+        [InlineKeyboardButton("Завершить", callback_data=f"{prefix}:finish")],
     ]
     return InlineKeyboardMarkup(rows)
 

--- a/tests/test_test_mode_flow.py
+++ b/tests/test_test_mode_flow.py
@@ -1,0 +1,111 @@
+import asyncio
+import os
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+
+
+# Ensure the application can import by providing a dummy token
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token")
+
+import bot.handlers_test as ht  # noqa: E402
+import app  # noqa: E402
+
+# ``handlers_test`` may have failed to import DATA if ``app`` was not available
+# earlier.  Ensure the global is populated for the test run.
+if ht.DATA is None:  # pragma: no cover - defensive
+    ht.DATA = app.DATA
+
+cb_test = ht.cb_test
+
+
+class DummyBot:
+    """Minimal bot stub collecting sent messages."""
+
+    def __init__(self):
+        self.sent: list[tuple[int, str, object | None]] = []
+
+    async def send_message(self, chat_id, text, reply_markup=None, parse_mode=None):
+        self.sent.append((chat_id, text, reply_markup))
+
+
+def test_full_test_flow(monkeypatch):
+    async def run():
+        # avoid real delays during the flow
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+
+        bot = DummyBot()
+        context = SimpleNamespace(bot=bot, user_data={})
+
+        # --- start session with random countries ---
+        q_start = SimpleNamespace(
+            data="test:random30",
+            answer=AsyncMock(),
+            edit_message_text=AsyncMock(),
+            message=SimpleNamespace(chat_id=123),
+        )
+        update = SimpleNamespace(
+            callback_query=q_start,
+            effective_chat=SimpleNamespace(id=123),
+            effective_user=SimpleNamespace(id=1),
+        )
+        await cb_test(update, context)
+
+        session = context.user_data["test_session"]
+        assert session.stats["total"] == 1
+
+        # buttons should carry the test prefix
+        markup = q_start.edit_message_text.await_args.kwargs["reply_markup"]
+        assert all(
+            btn.callback_data.startswith("test:")
+            for row in markup.inline_keyboard
+            for btn in row
+            if btn.callback_data
+        )
+
+        # --- reveal answer ---
+        q_show = SimpleNamespace(
+            data="test:show",
+            answer=AsyncMock(),
+            edit_message_text=AsyncMock(),
+            message=q_start.message,
+        )
+        update.callback_query = q_show
+        await cb_test(update, context)
+        q_show.edit_message_text.assert_awaited()
+
+        # --- next question and answer correctly ---
+        q_next = SimpleNamespace(
+            data="test:next",
+            answer=AsyncMock(),
+            edit_message_text=AsyncMock(),
+            message=q_start.message,
+        )
+        update.callback_query = q_next
+        await cb_test(update, context)
+        q_next.edit_message_text.assert_awaited()
+
+        current = context.user_data["test_session"].current
+        idx = current["options"].index(current["answer"])
+        q_ans = SimpleNamespace(
+            data=f"test:opt:{idx}",
+            answer=AsyncMock(),
+            edit_message_reply_markup=AsyncMock(),
+            message=SimpleNamespace(chat_id=123),
+        )
+        update.callback_query = q_ans
+        await cb_test(update, context)
+        assert context.user_data["test_session"].stats["correct"] >= 1
+
+        # --- finish session ---
+        q_finish = SimpleNamespace(
+            data="test:finish",
+            answer=AsyncMock(),
+            message=SimpleNamespace(chat_id=123),
+        )
+        update.callback_query = q_finish
+        await cb_test(update, context)
+        assert "test_session" not in context.user_data
+        assert bot.sent, "No final message sent"
+
+    asyncio.run(run())
+


### PR DESCRIPTION
## Summary
- allow `cards_kb` and `cards_answer_kb` to take a prefix for callback data
- use the `test` prefix in test-mode handler and ignore spacer clicks
- add integration test covering the full test-mode flow

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c6c7daefc883269217dd531c60e8a0