### PR TITLE
Add sprint stop control with timer cancellation

### DIFF
--- a/bot/handlers_sprint.py
+++ b/bot/handlers_sprint.py
@@ -134,6 +134,19 @@ async def cb_sprint(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         except (TelegramError, HTTPError) as e:
             logger.warning("Failed to return to menu: %s", e)
         return
+    if action == "stop":
+        await q.answer()
+        job = context.user_data.pop("sprint_job", None)
+        if job:
+            job.schedule_removal()
+        context.user_data.pop("sprint_session", None)
+        context.user_data.pop("sprint_allow_skip", None)
+        try:
+            await q.edit_message_text(WELCOME, reply_markup=main_menu_kb())
+        except (TelegramError, HTTPError) as e:
+            logger.warning("Failed to return to menu: %s", e)
+        logger.info("Sprint stopped early by user %s", update.effective_user.id)
+        return
     if action not in {"opt", "skip"}:
         await q.answer()
         # Session setup: sprint:<continent>

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -217,9 +217,11 @@ def sprint_kb(options: list[str], allow_skip: bool = True) -> InlineKeyboardMark
                 buffer = []
     if buffer:
         rows.append(buffer)
+    # spacer row to visually separate options from action buttons
+    rows.append([InlineKeyboardButton(SPACER, callback_data="sprint:void")])
     if allow_skip:
-        rows.append([InlineKeyboardButton(SPACER, callback_data="sprint:void")])
         rows.append([InlineKeyboardButton("Пропустить", callback_data="sprint:skip")])
+    rows.append([InlineKeyboardButton("Прервать игру", callback_data="sprint:stop")])
     return InlineKeyboardMarkup(rows)
 
 

--- a/tests/test_sprint_stop.py
+++ b/tests/test_sprint_stop.py
@@ -1,0 +1,54 @@
+import asyncio
+from types import SimpleNamespace
+
+from bot.handlers_sprint import cb_sprint
+from bot.state import SprintSession
+from bot.handlers_menu import WELCOME, main_menu_kb
+
+
+class DummyJob:
+    def __init__(self):
+        self.removed = False
+        self.ran = False
+
+    def schedule_removal(self):
+        self.removed = True
+
+    def run(self):
+        if not self.removed:
+            self.ran = True
+
+
+class DummyQuery:
+    def __init__(self):
+        self.data = "sprint:stop"
+        self.message = SimpleNamespace(chat_id=1)
+        self.answered = False
+        self.edited: list[tuple[str, object]] = []
+
+    async def answer(self):
+        self.answered = True
+
+    async def edit_message_text(self, text, reply_markup=None):
+        self.edited.append((text, reply_markup))
+
+
+def test_sprint_stop_cancels_timer_and_returns_to_menu():
+    job = DummyJob()
+    session = SprintSession(user_id=1, duration_sec=60)
+    context = SimpleNamespace(user_data={"sprint_session": session, "sprint_job": job})
+    q = DummyQuery()
+    update = SimpleNamespace(callback_query=q, effective_user=SimpleNamespace(id=1))
+
+    asyncio.run(cb_sprint(update, context))
+
+    assert q.answered, "Callback was not answered"
+    assert job.removed, "Timer job was not cancelled"
+    assert "sprint_session" not in context.user_data
+    assert "sprint_job" not in context.user_data
+    assert q.edited, "Main menu was not shown"
+    text, markup = q.edited[0]
+    assert text == WELCOME
+    assert markup.inline_keyboard == main_menu_kb().inline_keyboard
+    job.run()
+    assert not job.ran, "Timer job ran after being cancelled"


### PR DESCRIPTION
## Summary
- Add "Прервать игру" stop button to sprint keyboard
- Handle `sprint:stop` callback to cancel timer, clear session, and log the stop
- Test that stopping sprint cancels timer and returns to main menu

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c6e5a3025483269da7965cce073b6a