### PR TITLE
Ensure capital line is always shown for capital questions

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -231,9 +231,10 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 get_user_stats(context.user_data).to_repeat.discard(item)
                 session.stats["known"] += 1
             fact = get_static_fact(current["country"])
-            text = f"✅ Верно\n{current['country']}"
-            if current["type"] == "country_to_capital":
-                text += f"\nСтолица: {current['capital']}"
+            text = (
+                f"✅ Верно\n{current['country']}"
+                f"\nСтолица: {current['capital']}"
+            )
             fact_msg = (
                 f"{text}\n\n{fact}\n\nНажми кнопку ниже, чтобы узнать еще один факт"
             )
@@ -329,9 +330,7 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             await q.edit_message_reply_markup(None)
         except (TelegramError, HTTPError) as e:
             logger.warning("Failed to clear card buttons: %s", e)
-        text = current["country"]
-        if current["type"] == "country_to_capital":
-            text += f"\nСтолица: {current['capital']}"
+        text = f"{current['country']}\nСтолица: {current['capital']}"
         fact = get_static_fact(current["country"])
         fact_msg = (
             f"{text}\n\n{fact}\n\nНажми кнопку ниже, чтобы узнать еще один факт"

--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -128,9 +128,8 @@ async def _bot_move(context: ContextTypes.DEFAULT_TYPE) -> None:
         f"Игрок 2 → {session.answer_options.get(session.players[1], '-') } {'✅' if session.answers.get(session.players[1]) else '❌'}\n"
         f"Бот-соперник → {'✅' if bot_correct else '❌'}\n"
         f"Правильный ответ: <b>{correct_display}</b>\n"
+        f"Столица: {session.current_question['capital']}\n"
     )
-    if session.current_question["type"] == "country_to_capital":
-        result_text += f"Столица: {session.current_question['capital']}\n"
     result_text += (
         f"Счёт: Команда {session.team_score} — Бот {session.bot_score} (Раунд {session.current_round}/{session.total_rounds})"
     )

--- a/bot/handlers_sprint.py
+++ b/bot/handlers_sprint.py
@@ -195,9 +195,10 @@ async def cb_sprint(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         if option == session.current["correct"]:
             session.score += 1
             await q.answer()
-            text = f"✅ Верно\n{session.current['country']}"
-            if session.current["type"] == "country_to_capital":
-                text += f"\nСтолица: {session.current['capital']}"
+            text = (
+                f"✅ Верно\n{session.current['country']}"
+                f"\nСтолица: {session.current['capital']}"
+            )
             flag_path = get_flag_image_path(session.current["country"])
             try:
                 await q.edit_message_reply_markup(None)

--- a/bot/handlers_test.py
+++ b/bot/handlers_test.py
@@ -176,9 +176,7 @@ async def cb_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 f"Осталось вопросов {len(session.queue)})"
             )
             fact = get_static_fact(current["country"])
-            text = current["country"]
-            if current["type"] == "country_to_capital":
-                text += f"\nСтолица: {current['capital']}"
+            text = f"{current['country']}\nСтолица: {current['capital']}"
             fact_msg = (
                 f"{progress}\n\n{text}\n\n{fact}\n\nНажми кнопку ниже, чтобы узнать еще один факт"
             )
@@ -261,9 +259,7 @@ async def cb_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         except (TelegramError, HTTPError) as e:
             logger.warning("Failed to clear test buttons: %s", e)
         fact = get_static_fact(current["country"])
-        text = current["country"]
-        if current["type"] == "country_to_capital":
-            text += f"\nСтолица: {current['capital']}"
+        text = f"{current['country']}\nСтолица: {current['capital']}"
         fact_msg = (
             f"{text}\n\n{fact}\n\nНажми кнопку ниже, чтобы узнать еще один факт"
         )

--- a/tests/test_capital_line.py
+++ b/tests/test_capital_line.py
@@ -1,0 +1,199 @@
+import asyncio
+from types import SimpleNamespace
+from unittest.mock import AsyncMock
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token")
+
+import app  # noqa: E402
+import bot.handlers_cards as hc
+import bot.handlers_sprint as hs
+import bot.handlers_test as ht
+import bot.handlers_coop as hco
+
+from bot.state import CardSession, SprintSession, TestSession, CoopSession
+
+cb_cards = hc.cb_cards
+cb_sprint = hs.cb_sprint
+cb_test = ht.cb_test
+
+
+class DummyBot:
+    """Collects sent messages for assertions."""
+
+    def __init__(self):
+        self.sent: list[tuple[int, str | None, object | None]] = []
+
+    async def send_message(self, chat_id, text, reply_markup=None, parse_mode=None):
+        self.sent.append((chat_id, text, reply_markup))
+        return SimpleNamespace(message_id=len(self.sent), text=text)
+
+    async def send_photo(self, chat_id, photo, caption=None, reply_markup=None, parse_mode=None):
+        self.sent.append((chat_id, caption, reply_markup))
+        return SimpleNamespace(message_id=len(self.sent), caption=caption)
+
+
+def test_cards_capital_question_includes_capital_line(monkeypatch):
+    async def run():
+        bot = DummyBot()
+        session = CardSession(user_id=1, queue=["next"])
+        session.current = {
+            "country": "Канада",
+            "capital": "Оттава",
+            "type": "capital_to_country",
+            "options": ["Канада"],
+            "answer": "Канада",
+        }
+        context = SimpleNamespace(user_data={"card_session": session}, bot=bot)
+        q = SimpleNamespace(
+            data="cards:opt:0",
+            answer=AsyncMock(),
+            edit_message_reply_markup=AsyncMock(),
+            message=SimpleNamespace(chat_id=1),
+        )
+        update = SimpleNamespace(callback_query=q)
+        monkeypatch.setattr(hc, "get_flag_image_path", lambda c: None)
+        monkeypatch.setattr(hc, "_next_card", AsyncMock())
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+        await cb_cards(update, context)
+        assert any("Столица: Оттава" in m[1] for m in bot.sent)
+
+        # show answer branch
+        bot.sent.clear()
+        session.current = {
+            "country": "Канада",
+            "capital": "Оттава",
+            "type": "capital_to_country",
+            "answer": "Канада",
+        }
+        q_show = SimpleNamespace(
+            data="cards:show",
+            answer=AsyncMock(),
+            edit_message_reply_markup=AsyncMock(),
+            message=SimpleNamespace(chat_id=1),
+        )
+        update.callback_query = q_show
+        await cb_cards(update, context)
+        assert any("Столица: Оттава" in m[1] for m in bot.sent)
+
+    asyncio.run(run())
+
+
+def test_sprint_capital_question_includes_capital_line(monkeypatch):
+    async def run():
+        bot = DummyBot()
+        session = SprintSession(user_id=1)
+        session.current = {
+            "country": "Канада",
+            "capital": "Оттава",
+            "type": "capital_to_country",
+            "options": ["Канада"],
+            "correct": "Канада",
+        }
+        context = SimpleNamespace(user_data={"sprint_session": session}, bot=bot)
+        q = SimpleNamespace(
+            data="sprint:opt:0",
+            answer=AsyncMock(),
+            edit_message_reply_markup=AsyncMock(),
+            message=SimpleNamespace(chat_id=1),
+        )
+        update = SimpleNamespace(callback_query=q)
+        monkeypatch.setattr(hs, "get_flag_image_path", lambda c: None)
+        monkeypatch.setattr(hs, "_ask_question", AsyncMock())
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+        await cb_sprint(update, context)
+        assert any("Столица: Оттава" in m[1] for m in bot.sent)
+
+    asyncio.run(run())
+
+
+def test_test_capital_question_includes_capital_line(monkeypatch):
+    async def run():
+        bot = DummyBot()
+        session = TestSession(user_id=1, queue=[], total_questions=1)
+        session.current = {
+            "country": "Канада",
+            "capital": "Оттава",
+            "type": "capital_to_country",
+            "prompt": "Оттава?",
+            "answer": "Канада",
+            "options": ["Канада"],
+        }
+        context = SimpleNamespace(user_data={"test_session": session}, bot=bot)
+        q = SimpleNamespace(
+            data="test:opt:0",
+            answer=AsyncMock(),
+            edit_message_reply_markup=AsyncMock(),
+            message=SimpleNamespace(chat_id=1),
+        )
+        update = SimpleNamespace(callback_query=q)
+        monkeypatch.setattr(ht, "get_flag_image_path", lambda c: None)
+        monkeypatch.setattr(ht, "_next_question", AsyncMock())
+        monkeypatch.setattr(asyncio, "sleep", AsyncMock())
+        await cb_test(update, context)
+        assert any("Столица: Оттава" in m[1] for m in bot.sent)
+
+        # show answer branch
+        bot.sent.clear()
+        session.current = {
+            "country": "Канада",
+            "capital": "Оттава",
+            "type": "capital_to_country",
+            "prompt": "Оттава?",
+            "answer": "Канада",
+        }
+        q_show = SimpleNamespace(
+            data="test:show",
+            answer=AsyncMock(),
+            edit_message_reply_markup=AsyncMock(),
+            message=SimpleNamespace(chat_id=1),
+        )
+        update.callback_query = q_show
+        await cb_test(update, context)
+        assert any("Столица: Оттава" in m[1] for m in bot.sent)
+
+    asyncio.run(run())
+
+
+def test_coop_bot_move_includes_capital_line(monkeypatch):
+    async def run():
+        bot = DummyBot()
+        session = CoopSession(
+            session_id="s1",
+            players=[1, 2],
+            player_chats={1: 1, 2: 2},
+            total_rounds=2,
+            current_round=1,
+        )
+        session.current_question = {
+            "country": "Канада",
+            "capital": "Оттава",
+            "type": "capital_to_country",
+            "prompt": "Оттава?",
+            "correct": "Канада",
+        }
+        session.answers = {1: True, 2: False}
+        session.answer_options = {1: "Канада", 2: "Бразилия"}
+
+        class DummyQueue:
+            def run_once(self, callback, delay, data=None, name=None):
+                return SimpleNamespace()
+
+        context = SimpleNamespace(
+            job=SimpleNamespace(data={"session_id": "s1"}),
+            application=SimpleNamespace(
+                bot_data={"coop_sessions": {"s1": session}}, job_queue=DummyQueue()
+            ),
+            bot=bot,
+        )
+        monkeypatch.setattr(hco, "get_flag_image_path", lambda c: None)
+        monkeypatch.setattr(hco.random, "random", lambda: 1.0)
+        monkeypatch.setattr(hco.random, "uniform", lambda a, b: a)
+        await hco._bot_move(context)
+        assert bot.sent
+        assert all("Столица: Оттава" in m[1] for m in bot.sent)
+
+    asyncio.run(run())


### PR DESCRIPTION
## Summary
- Always append `Столица: ...` in flash-card feedback and "show answer" responses
- Include capital line for sprint, test, and coop modes
- Add tests verifying capital line output across all modes

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c711c2a1f88326a3936dcb3559176a