### PR TITLE
Fix coop session creation from menu callbacks

### DIFF
--- a/bot/handlers_menu.py
+++ b/bot/handlers_menu.py
@@ -129,11 +129,9 @@ async def cb_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await context.bot.send_message(chat_id, chunks[-1], reply_markup=list_result_kb())
 
     elif data == "menu:coop":
-        from telegram import Update
         from .handlers_coop import cmd_coop_capitals
 
-        fake_update = Update(update.update_id, message=q.message)
-        await cmd_coop_capitals(fake_update, context)
+        await cmd_coop_capitals(update, context)
         try:
             await q.message.delete()
         except Exception:

--- a/tests/test_coop_cancel.py
+++ b/tests/test_coop_cancel.py
@@ -1,0 +1,45 @@
+import asyncio
+from types import SimpleNamespace
+
+from bot.handlers_coop import cmd_coop_capitals, cmd_coop_cancel
+
+
+class DummyBot:
+    def __init__(self):
+        self.sent = []
+
+    async def send_message(self, chat_id, text, reply_markup=None):
+        self.sent.append((chat_id, text))
+
+
+def test_coop_capitals_from_callback_and_cancel():
+    context = SimpleNamespace(
+        bot=DummyBot(),
+        user_data={},
+        application=SimpleNamespace(bot_data={}),
+    )
+
+    update_cb = SimpleNamespace(
+        effective_user=SimpleNamespace(id=1),
+        effective_chat=SimpleNamespace(id=100, type="private"),
+        message=None,
+    )
+
+    asyncio.run(cmd_coop_capitals(update_cb, context))
+
+    sessions = context.application.bot_data.get("coop_sessions")
+    assert sessions, "Session was not created"
+    session = next(iter(sessions.values()))
+    assert session.players == [1], "Wrong user registered"
+
+    cancel_update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=1),
+        effective_chat=SimpleNamespace(id=100),
+        message=SimpleNamespace(),
+    )
+
+    asyncio.run(cmd_coop_cancel(cancel_update, context))
+
+    assert not context.application.bot_data["coop_sessions"], "Session was not cancelled"
+    assert any(text == "Матч отменён" for _, text in context.bot.sent)
+


### PR DESCRIPTION
## Summary
- Call `cmd_coop_capitals` with the original update in menu callback
- Make `cmd_coop_capitals` handle callback queries without messages
- Add regression test ensuring `/coop_cancel` removes session

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c71e62e7f4832689379b1c0fc5fef9