### PR TITLE
Add admin-only dummy cooperative test mode

### DIFF
--- a/bot/handlers_menu.py
+++ b/bot/handlers_menu.py
@@ -1,5 +1,6 @@
 """Handlers for the main menu flow."""
 
+import os
 import random
 
 from telegram import Update
@@ -14,8 +15,11 @@ from .keyboards import (
     list_result_kb,
     back_to_menu_kb,
     test_start_kb,
+    coop_admin_kb,
 )
 from .flags import get_country_flag
+
+ADMIN_ID = int(os.getenv("ADMIN_ID", "0"))
 
 WELCOME = (
     "Привет! Это бот для тренировки знаний столицы ↔ страна.\n"
@@ -129,13 +133,18 @@ async def cb_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
             await context.bot.send_message(chat_id, chunks[-1], reply_markup=list_result_kb())
 
     elif data == "menu:coop":
-        from .handlers_coop import cmd_coop_capitals
+        if update.effective_user.id == ADMIN_ID:
+            await q.edit_message_text(
+                "Доступен тестовый матч.", reply_markup=coop_admin_kb()
+            )
+        else:
+            from .handlers_coop import cmd_coop_capitals
 
-        await cmd_coop_capitals(update, context)
-        try:
-            await q.message.delete()
-        except Exception:
-            pass
+            await cmd_coop_capitals(update, context)
+            try:
+                await q.message.delete()
+            except Exception:
+                pass
 
     elif data == "menu:main":
         await q.edit_message_text(WELCOME, reply_markup=main_menu_kb())

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -259,6 +259,16 @@ def coop_join_kb(session_id: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(rows)
 
 
+def coop_admin_kb() -> InlineKeyboardMarkup:
+    """Admin-only keyboard with a test match button."""
+
+    rows = [
+        [InlineKeyboardButton("[адм.]\u202fТестовая игра", callback_data="coop:test")],
+        [InlineKeyboardButton("В меню", callback_data="menu:main")],
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
 def coop_invite_kb() -> ReplyKeyboardMarkup:
     """Keyboard for inviting the second player."""
 

--- a/bot/state.py
+++ b/bot/state.py
@@ -147,6 +147,8 @@ class CoopSession:
     question_message_ids: Dict[int, int] = field(default_factory=dict)
     current_question: Dict[str, Any] | None = None
     jobs: Dict[str, Job] = field(default_factory=dict)
+    dummy_mode: bool = False
+    dummy_counter: int = 0
 
 
 @dataclass

--- a/tests/test_dummy_coop.py
+++ b/tests/test_dummy_coop.py
@@ -1,0 +1,131 @@
+import asyncio
+from types import SimpleNamespace
+
+
+def test_admin_button_visible_only_for_admin(monkeypatch):
+    monkeypatch.setenv("ADMIN_ID", "1")
+    import bot.handlers_menu as hm
+    hm.ADMIN_ID = 1
+
+    class DummyCQ:
+        def __init__(self):
+            self.data = "menu:coop"
+            self.markup = None
+
+        async def answer(self, *args, **kwargs):
+            pass
+
+        async def edit_message_text(self, text, reply_markup=None):
+            self.markup = reply_markup
+
+    update = SimpleNamespace(
+        callback_query=DummyCQ(), effective_user=SimpleNamespace(id=1)
+    )
+    context = SimpleNamespace()
+    asyncio.run(hm.cb_menu(update, context))
+    assert update.callback_query.markup is not None
+    buttons = [
+        btn.text for row in update.callback_query.markup.inline_keyboard for btn in row
+    ]
+    assert any("[адм.]" in b for b in buttons)
+
+    # Non-admin should not see the button
+    class Bot:
+        def __init__(self):
+            self.sent = []
+
+        async def send_message(self, chat_id, text, reply_markup=None):
+            self.sent.append((chat_id, text, reply_markup))
+
+    bot = Bot()
+    q = DummyCQ()
+    update2 = SimpleNamespace(
+        callback_query=q,
+        effective_user=SimpleNamespace(id=2),
+        effective_chat=SimpleNamespace(id=100, type="private"),
+        message=None,
+    )
+    context2 = SimpleNamespace(
+        bot=bot, user_data={}, application=SimpleNamespace(bot_data={})
+    )
+    asyncio.run(hm.cb_menu(update2, context2))
+    assert q.markup is None
+
+
+def test_dummy_player_cycle(monkeypatch):
+    monkeypatch.setenv("ADMIN_ID", "1")
+    import bot.handlers_coop as hco
+    hco.ADMIN_ID = 1
+
+    class DummyBot:
+        def __init__(self):
+            self.sent = []
+
+        async def send_message(self, chat_id, text, reply_markup=None, parse_mode=None):
+            self.sent.append((chat_id, text))
+            return SimpleNamespace(message_id=len(self.sent))
+
+    class DummyQueue:
+        def run_once(self, callback, delay, data=None, name=None):
+            return SimpleNamespace(schedule_removal=lambda: None)
+
+    bot = DummyBot()
+    context = SimpleNamespace(
+        bot=bot,
+        user_data={},
+        application=SimpleNamespace(bot_data={}, job_queue=DummyQueue()),
+    )
+    update = SimpleNamespace(
+        effective_user=SimpleNamespace(id=1),
+        effective_chat=SimpleNamespace(id=1, type="private"),
+        message=None,
+    )
+
+    monkeypatch.setattr(hco, "get_flag_image_path", lambda c: None)
+
+    def fake_question(data, continent, mode):
+        return {
+            "prompt": "Q?",
+            "options": ["A", "B", "C", "D"],
+            "correct": "A",
+            "country": "X",
+            "capital": "A",
+            "type": "country_to_capital",
+        }
+
+    monkeypatch.setattr(hco, "pick_question", fake_question)
+    monkeypatch.setattr(hco.random, "random", lambda: 1.0)
+    monkeypatch.setattr(hco.random, "uniform", lambda a, b: a)
+
+    asyncio.run(hco.cmd_coop_test(update, context))
+    session = next(iter(context.application.bot_data["coop_sessions"].values()))
+
+    for i in range(3):
+        qdata = f"coop:ans:{session.session_id}:1:1"
+        cq = SimpleNamespace(data=qdata)
+
+        async def answer(*args, **kwargs):
+            pass
+
+        async def edit_message_reply_markup(*args, **kwargs):
+            pass
+
+        cq.answer = answer
+        cq.edit_message_reply_markup = edit_message_reply_markup
+        cb_update = SimpleNamespace(callback_query=cq, effective_user=SimpleNamespace(id=1))
+        asyncio.run(hco.cb_coop(cb_update, context))
+        bot_ctx = SimpleNamespace(
+            job=SimpleNamespace(data={"session_id": session.session_id}),
+            application=context.application,
+            bot=bot,
+        )
+        asyncio.run(hco._bot_move(bot_ctx))
+        session = context.application.bot_data.get("coop_sessions", {}).get(session.session_id)
+        if session:
+            asyncio.run(hco._start_round(context, session))
+
+    results = [msg for _, msg in bot.sent if "Игрок 2" in msg]
+    assert len(results) >= 3
+    assert "Игрок 2" in results[0] and "✅" in results[0]
+    assert "Игрок 2" in results[1] and "✅" in results[1]
+    assert "Игрок 2" in results[2] and "❌" in results[2]


### PR DESCRIPTION
## Summary
- Show admin-only "[адм.] Тестовая игра" option in coop menu
- Support dummy cooperative sessions with automatic 2/3 correct answers
- Cover admin visibility and dummy player behavior with tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_68c79ec315988326886e2fcb55c0d9c8