### PR TITLE
Implement turn-based cooperative game logic

### DIFF
--- a/bot/state.py
+++ b/bot/state.py
@@ -140,7 +140,6 @@ class CoopSession:
     current_round: int = 0
     team_score: int = 0
     bot_score: int = 0
-    current_turn_index: int = 0
     bot_think_delay: float = 2.0
     answers: Dict[int, bool] = field(default_factory=dict)
     answer_options: Dict[int, str] = field(default_factory=dict)
@@ -149,6 +148,10 @@ class CoopSession:
     jobs: Dict[str, Job] = field(default_factory=dict)
     dummy_mode: bool = False
     dummy_counter: int = 0
+    remaining_pairs: List[Dict[str, Any]] = field(default_factory=list)
+    current_pair: Dict[str, Any] | None = None
+    turn_index: int = 0
+    player_stats: Dict[int, int] = field(default_factory=dict)
 
 
 @dataclass

--- a/tests/test_coop_game.py
+++ b/tests/test_coop_game.py
@@ -1,0 +1,59 @@
+import asyncio
+from types import SimpleNamespace
+
+
+def _setup_session(monkeypatch, continent=None):
+    import importlib
+    import bot.handlers_coop as hco
+    hco = importlib.reload(hco)
+    monkeypatch.setattr(hco, "coop_answer_kb", lambda *args, **kwargs: None)
+
+    class DummyBot:
+        def __init__(self):
+            self.sent = []
+
+        async def send_message(self, chat_id, text, reply_markup=None, parse_mode=None):
+            self.sent.append((chat_id, text))
+            return SimpleNamespace(message_id=len(self.sent))
+
+    bot = DummyBot()
+    context = SimpleNamespace(
+        bot=bot,
+        application=SimpleNamespace(bot_data={}),
+    )
+
+    session = hco.CoopSession(session_id="s1")
+    session.players = [1, 2]
+    session.player_chats = {1: 1, 2: 2}
+    session.player_names = {1: "A", 2: "B"}
+    session.continent_filter = continent
+    context.application.bot_data["coop_sessions"] = {"s1": session}
+    return hco, session, context, bot
+
+
+def test_question_stays_on_wrong_answer(monkeypatch):
+    hco, session, context, bot = _setup_session(monkeypatch, continent="Европа")
+    asyncio.run(hco._start_game(context, session))
+    first = bot.sent[0][1]
+    asyncio.run(hco._next_turn(context, session, False))
+    second = bot.sent[2][1]
+    assert first.split("\n", 1)[1] == second.split("\n", 1)[1]
+    assert len(session.remaining_pairs) > 0
+
+
+def test_turn_order_cycles(monkeypatch):
+    hco, session, context, bot = _setup_session(monkeypatch, continent="Европа")
+    asyncio.run(hco._start_game(context, session))
+    asyncio.run(hco._next_turn(context, session, False))
+    assert session.turn_index == 1
+    asyncio.run(hco._next_turn(context, session, False))
+    assert session.turn_index == 0
+    chats = [bot.sent[i][0] for i in range(0, len(bot.sent), 2)]
+    assert chats[:3] == [1, 2, 1]
+
+
+def test_world_mode_limit(monkeypatch):
+    hco, session, context, bot = _setup_session(monkeypatch, continent=None)
+    monkeypatch.setattr(hco.random, "sample", lambda seq, k: list(seq)[:k])
+    asyncio.run(hco._start_game(context, session))
+    assert len(session.remaining_pairs) == 30


### PR DESCRIPTION
## Summary
- extend CoopSession with queue, current pair, turn index and per-player stats
- add turn-based cooperative helpers to manage asking and advancing through pairs
- cover cooperative game flow with tests for turn order, question persistence and world mode limits

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c7fa34c4608326b1d5470ad5cf704e