### PR TITLE
Add restart hint to missing session messages

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -214,7 +214,9 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not session or not hasattr(session, "current"):
         await q.answer()
         try:
-            await q.edit_message_text("Сессия не найдена")
+            await q.edit_message_text(
+                "Сессия не найдена. Нажмите /start, чтобы начать заново."
+            )
         except (TelegramError, HTTPError) as e:
             logger.warning("Failed to notify missing session: %s", e)
         return

--- a/bot/handlers_test.py
+++ b/bot/handlers_test.py
@@ -154,7 +154,10 @@ async def cb_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     if not session or not hasattr(session, "current"):
         await q.answer()
         try:
-            await q.edit_message_text("Сессия не найдена", reply_markup=back_to_menu_kb())
+            await q.edit_message_text(
+                "Сессия не найдена. Нажмите /start, чтобы начать заново.",
+                reply_markup=back_to_menu_kb(),
+            )
         except (TelegramError, HTTPError) as e:
             logger.warning("Failed to notify missing session: %s", e)
         return


### PR DESCRIPTION
## Summary
- instruct users to press /start when a session is missing in card and test handlers

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c7faddb4088326a3884f2e93e3a892