### PR TITLE
Add extra pause after feedback in flashcard and test modes

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -293,7 +293,7 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             except (TelegramError, HTTPError) as e:
                 logger.warning("Failed to send card feedback: %s", e)
         session.current_answered = True
-        await asyncio.sleep(3)
+        await asyncio.sleep(5)
         await _next_card(update, context, replace_message=False)
         return
 
@@ -369,7 +369,7 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             session.fact_subject = current["country"]
             session.fact_text = fact
         session.current_answered = True
-        await asyncio.sleep(3)
+        await asyncio.sleep(5)
         await _next_card(update, context, replace_message=False)
         return
 

--- a/bot/handlers_test.py
+++ b/bot/handlers_test.py
@@ -219,7 +219,7 @@ async def cb_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 await context.bot.send_message(q.message.chat_id, text, parse_mode="HTML")
             except (TelegramError, HTTPError) as e:
                 logger.warning("Failed to send test feedback: %s", e)
-        await asyncio.sleep(2)
+        await asyncio.sleep(4)
         await _next_question(update, context, replace_message=False)
         return
 
@@ -292,7 +292,7 @@ async def cb_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
             session.fact_message_id = msg.message_id
             session.fact_subject = current["country"]
             session.fact_text = fact
-        await asyncio.sleep(2)
+        await asyncio.sleep(4)
         await _next_question(update, context, replace_message=False)
         return
 


### PR DESCRIPTION
## Summary
- Extend post-feedback pause in flashcard mode from 3s to 5s
- Extend post-feedback pause in test mode from 2s to 4s

## Testing
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68c815a89d58832695c46e13ea296a4d