### PR TITLE
Fix coop menu initialization and expose card answers

### DIFF
--- a/bot/handlers_menu.py
+++ b/bot/handlers_menu.py
@@ -72,9 +72,6 @@ async def cb_menu(update: Update, context: ContextTypes.DEFAULT_TYPE):
         from .handlers_coop import cmd_coop_capitals
 
         await q.edit_message_text("🤝 Дуэт против Бота")
-        update.effective_chat = q.message.chat
-        update.effective_user = q.from_user
-        update.message = None
         await cmd_coop_capitals(update, context)
     elif data == "menu:coop_admin":
         context.user_data["coop_admin"] = True

--- a/bot/questions.py
+++ b/bot/questions.py
@@ -104,5 +104,6 @@ def make_card_question(
         "capital": capital,
         "prompt": prompt,
         "answer": answer,
+        "correct": answer,
         "options": options,
     }


### PR DESCRIPTION
## Summary
- invoke the cooperative match setup directly from the menu callback without mutating the update
- add a `correct` entry to flash-card questions for consumers that expect that key

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8f7e0d23c8326ad03b3a48abcb156