### PR TITLE
Use chat_data for cooperative session storage

### DIFF
--- a/bot/handlers_quit.py
+++ b/bot/handlers_quit.py
@@ -5,7 +5,11 @@ from telegram.ext import ContextTypes
 from telegram.error import TelegramError
 from httpx import HTTPError
 
-from .handlers_coop import _get_sessions, _find_user_session
+from .handlers_coop import (
+    _get_sessions,
+    _find_user_session_global,
+    _remove_session,
+)
 
 
 SESSION_ENDED = "Сессия прекращена. Для запуска прогаммы используйте /start"
@@ -28,10 +32,10 @@ async def cmd_quit(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     ]:
         user_data.pop(key, None)
 
-    sessions = _get_sessions(context)
-    sid, session = _find_user_session(sessions, update.effective_user.id)
+    _get_sessions(context)
+    _, session = _find_user_session_global(context, update.effective_user.id)
     if session:
-        sessions.pop(sid, None)
+        _remove_session(context, session)
         for pid in session.players:
             chat_id = session.player_chats.get(pid, pid)
             try:

--- a/tests/test_capital_line.py
+++ b/tests/test_capital_line.py
@@ -172,8 +172,11 @@ def test_coop_bot_move_mentions_capital(monkeypatch):
             "correct": "Канада",
         }
         session.remaining_pairs = [session.current_pair]
+        chat_data = {"sessions": {"s1": session}}
         context = SimpleNamespace(
-            bot=bot, application=SimpleNamespace(bot_data={"coop_sessions": {"s1": session}})
+            bot=bot,
+            chat_data=chat_data,
+            application=SimpleNamespace(chat_data={1: chat_data}),
         )
         monkeypatch.setattr(hco.random, "random", lambda: 0.0)
         await hco._next_turn(context, session, False)

--- a/tests/test_coop_cancel.py
+++ b/tests/test_coop_cancel.py
@@ -13,10 +13,12 @@ class DummyBot:
 
 
 def test_coop_capitals_from_callback_and_cancel():
+    chat_data = {}
     context = SimpleNamespace(
         bot=DummyBot(),
         user_data={},
-        application=SimpleNamespace(bot_data={}),
+        chat_data=chat_data,
+        application=SimpleNamespace(chat_data={100: chat_data}),
     )
 
     update_cb = SimpleNamespace(
@@ -27,7 +29,7 @@ def test_coop_capitals_from_callback_and_cancel():
 
     asyncio.run(cmd_coop_capitals(update_cb, context))
 
-    sessions = context.application.bot_data.get("coop_sessions")
+    sessions = context.chat_data.get("sessions")
     assert sessions, "Session was not created"
     session = next(iter(sessions.values()))
     assert session.players == [1], "Wrong user registered"
@@ -40,6 +42,6 @@ def test_coop_capitals_from_callback_and_cancel():
 
     asyncio.run(cmd_coop_cancel(cancel_update, context))
 
-    assert not context.application.bot_data["coop_sessions"], "Session was not cancelled"
+    assert not context.chat_data.get("sessions"), "Session was not cancelled"
     assert any(text == "Матч отменён" for _, text in context.bot.sent)
 

--- a/tests/test_coop_game.py
+++ b/tests/test_coop_game.py
@@ -17,17 +17,18 @@ def _setup_session(monkeypatch, continent=None):
             return SimpleNamespace(message_id=len(self.sent))
 
     bot = DummyBot()
-    context = SimpleNamespace(
-        bot=bot,
-        application=SimpleNamespace(bot_data={}),
-    )
-
     session = hco.CoopSession(session_id="s1")
     session.players = [1, 2]
     session.player_chats = {1: 1, 2: 2}
     session.player_names = {1: "A", 2: "B"}
     session.continent_filter = continent
-    context.application.bot_data["coop_sessions"] = {"s1": session}
+    chat_data_1 = {"sessions": {"s1": session}}
+    chat_data_2 = {"sessions": {"s1": session}}
+    context = SimpleNamespace(
+        bot=bot,
+        chat_data=chat_data_1,
+        application=SimpleNamespace(chat_data={1: chat_data_1, 2: chat_data_2}),
+    )
     return hco, session, context, bot
 
 
@@ -47,10 +48,13 @@ def test_continent_prompt_after_names(monkeypatch):
     session = hco.CoopSession(session_id="s1")
     session.players = [1, 2]
     session.player_chats = {1: 1, 2: 2}
+    chat_data_1 = {"sessions": {"s1": session}}
+    chat_data_2 = {"sessions": {"s1": session}}
     context = SimpleNamespace(
         bot=bot,
         user_data={"coop_pending": {"session_id": "s1", "stage": "name"}},
-        application=SimpleNamespace(bot_data={"coop_sessions": {"s1": session}}),
+        chat_data=chat_data_2,
+        application=SimpleNamespace(chat_data={1: chat_data_1, 2: chat_data_2}),
     )
 
     async def reply_text(text, reply_markup=None):


### PR DESCRIPTION
## Summary
- keep cooperative session state in chat_data instead of bot_data and add helpers to locate/remove sessions across chats
- update cooperative handlers and /quit cleanup to rely on the chat-scoped helpers
- adjust tests to build chat_data fixtures for coop scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c8f8da69048326924af3456581804b