### PR TITLE
Add intro message and delay before first coop question

### DIFF
--- a/tests/test_coop_game.py
+++ b/tests/test_coop_game.py
@@ -7,6 +7,10 @@ def _setup_session(monkeypatch, continent=None):
     import bot.handlers_coop as hco
     hco = importlib.reload(hco)
     monkeypatch.setattr(hco, "coop_answer_kb", lambda *args, **kwargs: None)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
+    async def no_sleep(*args, **kwargs):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
 
     class DummyBot:
         def __init__(self):
@@ -73,9 +77,9 @@ def test_continent_prompt_after_names(monkeypatch):
 def test_question_stays_on_wrong_answer(monkeypatch):
     hco, session, context, bot = _setup_session(monkeypatch, continent="Европа")
     asyncio.run(hco._start_game(context, session))
-    first = bot.sent[0][1]
+    first = bot.sent[2][1]
     asyncio.run(hco._next_turn(context, session, False))
-    second = bot.sent[2][1]
+    second = bot.sent[4][1]
     assert first.split("\n", 1)[1] == second.split("\n", 1)[1]
     assert len(session.remaining_pairs) > 0
 

--- a/tests/test_dummy_coop.py
+++ b/tests/test_dummy_coop.py
@@ -4,6 +4,7 @@ from types import SimpleNamespace
 
 def test_admin_button_visible_only_for_admin(monkeypatch):
     monkeypatch.setenv("ADMIN_ID", "1")
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
     import importlib
     hm = importlib.reload(__import__("bot.handlers_menu", fromlist=["*"]))
     hm.ADMIN_ID = 1
@@ -41,6 +42,7 @@ def test_admin_button_visible_only_for_admin(monkeypatch):
 
 def test_coop_flow_steps(monkeypatch):
     import importlib
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
     hco = importlib.reload(__import__("bot.handlers_coop", fromlist=["*"]))
     monkeypatch.setenv("ADMIN_ID", "99")
     hco.ADMIN_ID = 99
@@ -120,20 +122,23 @@ def test_coop_flow_steps(monkeypatch):
 
 def test_cmd_coop_test_spawns_dummy_partner(monkeypatch):
     import importlib
-
+    async def no_sleep(*args, **kwargs):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
     monkeypatch.setenv("ADMIN_ID", "5")
     hco = importlib.reload(__import__("bot.handlers_coop", fromlist=["*"]))
     hco.ADMIN_ID = 5
     hco.DUMMY_ACCURACY = 1.0
 
-    monkeypatch.setattr(hco.DATA, "countries", lambda continent: ["France"])
+    monkeypatch.setattr(hco.DATA, "countries", lambda continent: ["Франция"])
 
     def fake_make_card_question(data, item, mode, continent):
         return {
             "prompt": "Q?",
             "options": ["A", "B", "C", "D"],
             "correct": "A",
-            "country": "France",
+            "country": "Франция",
             "capital": "A",
             "type": "country_to_capital",
         }
@@ -173,9 +178,9 @@ def test_cmd_coop_test_spawns_dummy_partner(monkeypatch):
     assert session.continent_filter == "Азия"
     assert "coop_pending" not in context.user_data
 
-    # Question sent immediately to the human player
-    assert bot.sent[0][0] == 77
-    assert "Ход" in bot.sent[0][1]
+    # Question sent after the intro message to the human player
+    assert bot.sent[1][0] == 77
+    assert "Ход" in bot.sent[1][1]
 
     # Simulate a wrong human answer -> dummy should answer automatically and finish the game
     asyncio.run(hco._next_turn(context, session, False))
@@ -188,6 +193,10 @@ def test_cmd_coop_test_spawns_dummy_partner(monkeypatch):
 
 
 def test_bot_accuracy(monkeypatch):
+    async def no_sleep(*args, **kwargs):
+        pass
+    monkeypatch.setattr(asyncio, "sleep", no_sleep)
+    monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
     monkeypatch.setenv("ADMIN_ID", "1")
     import importlib
     hco = importlib.reload(__import__("bot.handlers_coop", fromlist=["*"]))


### PR DESCRIPTION
## Summary
- show cooperative game intro describing turn order, total questions and win conditions
- wait 4 seconds before the first question
- update cooperative tests for new intro and to skip artificial delays

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68c92e44f3a08326aff9a4d5a742f83b