### PR TITLE
Add test-style feedback to cooperative mode

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -371,3 +371,10 @@ def coop_answer_kb(session_id: str, player_id: int, options: list[str]) -> Inlin
         rows.append(buffer)
     return InlineKeyboardMarkup(rows)
 
+
+def coop_fact_more_kb(session_id: str) -> InlineKeyboardMarkup:
+    """Keyboard with a button to request another fact."""
+
+    rows = [[InlineKeyboardButton("Еще один факт", callback_data=f"coop:more_fact:{session_id}")]]
+    return InlineKeyboardMarkup(rows)
+

--- a/bot/state.py
+++ b/bot/state.py
@@ -142,6 +142,10 @@ class CoopSession:
     turn_index: int = 0
     player_stats: Dict[int, int] = field(default_factory=dict)
     bot_stats: int = 0
+    total_pairs: int = 0
+    fact_message_ids: Dict[int, int] = field(default_factory=dict)
+    fact_subject: str | None = None
+    fact_text: str | None = None
 
 
 @dataclass

--- a/tests/test_capital_line.py
+++ b/tests/test_capital_line.py
@@ -175,6 +175,7 @@ def test_coop_bot_move_mentions_capital(monkeypatch):
             "correct": "Канада",
         }
         session.remaining_pairs = [session.current_pair]
+        session.total_pairs = 1
         chat_data = {"sessions": {"s1": session}}
         context = SimpleNamespace(
             bot=bot,

--- a/tests/test_dummy_coop.py
+++ b/tests/test_dummy_coop.py
@@ -206,7 +206,9 @@ def test_cmd_coop_test_spawns_dummy_partner(monkeypatch):
     dummy_photos = [entry for entry in bot.photos if entry[1] and "Бот-помощник отвечает верно" in entry[1]]
     assert dummy_photos
     assert all(chat_id == 77 for chat_id, *_ in dummy_photos)
-    opponent_photos = [entry for entry in bot.photos if entry[1] and entry[1].startswith("Бот отвечает")]
+    opponent_photos = [
+        entry for entry in bot.photos if entry[1] and "Бот отвечает верно" in entry[1]
+    ]
     assert opponent_photos
     assert opponent_photos[-1][0] == 77
     assert bot.sent[-1][1].startswith("Игра завершена.")
@@ -338,6 +340,7 @@ def test_bot_takes_turn_after_second_player(monkeypatch):
             "type": "country_to_capital",
         },
     ]
+    session.total_pairs = len(session.remaining_pairs)
 
     chat_data_1 = {"sessions": {"s1": session}}
     chat_data_2 = {"sessions": {"s1": session}}


### PR DESCRIPTION
## Summary
- Show Test-mode style feedback with progress, flag, and static fact for correct answers in coop matches
- Track total questions and support "Еще один факт" button via new coop callback
- Update coop session state and tests accordingly

## Testing
- `pytest`

------
https://chatgpt.com/codex/tasks/task_e_68c944542d28832698d972ef3d257bd7