### PR TITLE
Skip continent selection when coop continent is preselected

### DIFF
--- a/bot/state.py
+++ b/bot/state.py
@@ -134,6 +134,7 @@ class CoopSession:
     player_chats: Dict[int, int] = field(default_factory=dict)
     player_names: Dict[int, str] = field(default_factory=dict)
     continent_filter: str | None = None
+    continent_label: str | None = None
     mode: str = "mixed"
     difficulty: str = ""
     question_message_ids: Dict[int, int] = field(default_factory=dict)


### PR DESCRIPTION
## Summary
- persist the previously chosen continent on new cooperative sessions to reuse it
- bypass the continent prompt when both players join and jump straight to difficulty selection
- cover the shortcut with a dedicated cooperative game test

## Testing
- PYTHONPATH=. pytest tests/test_coop_game.py

------
https://chatgpt.com/codex/tasks/task_e_68c9547c44cc83268cb14ee8d9351610