### PR TITLE
Enhance coop score messages

### DIFF
--- a/tests/test_coop_game.py
+++ b/tests/test_coop_game.py
@@ -1,6 +1,7 @@
 import asyncio
 from types import SimpleNamespace
 from unittest.mock import AsyncMock
+from html import escape
 
 
 def _setup_session(monkeypatch, continent=None):
@@ -221,12 +222,19 @@ def test_score_broadcast_includes_team_total(monkeypatch):
     asyncio.run(hco._start_game(context, session))
     asyncio.run(hco._next_turn(context, session, True))
 
-    score_messages = [text for _, text, *_ in bot.sent if text and text.startswith("Текущий счёт:")]
+    score_messages = [
+        text
+        for _, text, *_ in bot.sent
+        if text and text.startswith("📊 <b>Текущий счёт</b>")
+    ]
     players_total = sum(session.player_stats.values())
     expected_remaining = max(session.total_pairs - (players_total + session.bot_stats), 0)
+    team_label = hco._format_team_label(session)
     expected = (
-        f"Текущий счёт: A и B — {players_total}, Бот — {session.bot_stats}. "
-        f"Осталось {expected_remaining} вопросов."
+        "📊 <b>Текущий счёт</b>\n"
+        f"🤝 <b>Команда</b> ({escape(team_label)}) — <b>{players_total}</b>\n"
+        f"🤖 <b>Бот-противник</b> — <b>{session.bot_stats}</b>\n"
+        f"{hco._format_remaining_questions_line(expected_remaining)}"
     )
     assert expected in score_messages
     assert not bot.photos

--- a/tests/test_dummy_coop.py
+++ b/tests/test_dummy_coop.py
@@ -1,5 +1,6 @@
 import asyncio
 from types import SimpleNamespace
+from html import escape
 
 
 def test_admin_button_visible_only_for_admin(monkeypatch):
@@ -215,7 +216,10 @@ def test_cmd_coop_test_spawns_dummy_partner(monkeypatch):
         entry for entry in bot.photos if entry[1] and "Бот отвечает верно" in entry[1]
     ]
     assert not opponent_photos
-    assert bot.sent[-1][1].startswith("Игра завершена.")
+    final_text = bot.sent[-1][1]
+    assert final_text.startswith("🏁 <b>Игра завершена!</b>")
+    assert "🤝 <b>Команда</b> (" in final_text
+    assert "🤖 <b>Бот-противник</b> — <b>" in final_text
     assert all(chat_id is not None for chat_id, *_ in bot.sent)
     assert session.player_stats[hco.DUMMY_PLAYER_ID] >= 1
     assert not sessions
@@ -392,12 +396,19 @@ def test_bot_takes_turn_after_second_player(monkeypatch):
     assert chats_for("Q2") == [2, 1]
     assert chats_for("Q3") == []
 
-    score_messages = [text for _, text, *_ in bot.sent if text.startswith("Текущий счёт:")]
+    score_messages = [
+        text
+        for _, text, *_ in bot.sent
+        if text and text.startswith("📊 <b>Текущий счёт</b>")
+    ]
     players_total = sum(session.player_stats.values())
     expected_remaining = max(session.total_pairs - (players_total + session.bot_stats), 0)
+    team_label = hco._format_team_label(session)
     expected_score = (
-        "Текущий счёт: Игрок 1 и Игрок 2 — "
-        f"{players_total}, Бот — {session.bot_stats}. Осталось {expected_remaining} вопросов."
+        "📊 <b>Текущий счёт</b>\n"
+        f"🤝 <b>Команда</b> ({escape(team_label)}) — <b>{players_total}</b>\n"
+        f"🤖 <b>Бот-противник</b> — <b>{session.bot_stats}</b>\n"
+        f"{hco._format_remaining_questions_line(expected_remaining)}"
     )
     assert expected_score in score_messages
 


### PR DESCRIPTION
## Summary
- stylize cooperative score updates with emojis, bold text, and proper team naming
- revise final game summary to show combined team vs bot totals with improved phrasing
- update cooperative mode tests to match the new messaging format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9a44067e0832692f82abeeda58923