### PR TITLE
Add cooperative finish keyboard and attach to final message

### DIFF
--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -26,6 +26,7 @@ from .keyboards import (
     coop_difficulty_kb,
     coop_continent_kb,
     coop_fact_more_kb,
+    coop_finish_kb,
 )
 from .flags import get_flag_image_path
 from .facts import get_static_fact, generate_llm_fact
@@ -542,12 +543,15 @@ async def _finish_game(context: ContextTypes.DEFAULT_TYPE, session: CoopSession)
         f"{bot_line}\n\n"
         f"{result_line}"
     )
+    keyboard = coop_finish_kb()
     for pid in session.players:
         chat_id = session.player_chats.get(pid)
         if not chat_id:
             continue
         try:
-            await context.bot.send_message(chat_id, text, parse_mode="HTML")
+            await context.bot.send_message(
+                chat_id, text, parse_mode="HTML", reply_markup=keyboard
+            )
         except (TelegramError, HTTPError) as e:
             logger.warning("Failed to send coop final result: %s", e)
 

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -380,3 +380,13 @@ def coop_fact_more_kb(session_id: str) -> InlineKeyboardMarkup:
     rows = [[InlineKeyboardButton("Еще один факт", callback_data=f"coop:more_fact:{session_id}")]]
     return InlineKeyboardMarkup(rows)
 
+
+def coop_finish_kb() -> InlineKeyboardMarkup:
+    """Keyboard shown after a cooperative match finishes."""
+
+    rows = [
+        [InlineKeyboardButton("Сыграть еще раз", callback_data="menu:coop")],
+        [InlineKeyboardButton("В меню", callback_data="menu:main")],
+    ]
+    return InlineKeyboardMarkup(rows)
+


### PR DESCRIPTION
## Summary
- add a dedicated finish keyboard for cooperative matches with replay and menu options
- attach the new keyboard to the cooperative mode final result message

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9a5f6ecb08326b08755e39b4ec34f