### PR TITLE
Update cooperative invite flow

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -2,6 +2,8 @@
 
 from textwrap import shorten
 from unicodedata import east_asian_width
+
+import telegram
 from telegram import (
     InlineKeyboardButton,
     InlineKeyboardMarkup,
@@ -16,6 +18,13 @@ LONG_OPTION = 15
 SECTION_WIDTH = 36
 LINE_CHAR = "─"
 SPACER = LINE_CHAR * 12
+COOP_INVITE_REQUEST_ID = 1001
+
+KeyboardButtonRequestUser = getattr(
+    telegram,
+    "KeyboardButtonRequestUser",
+    telegram.KeyboardButtonRequestUsers,
+)
 
 
 def _visible_len(text: str) -> int:
@@ -284,7 +293,15 @@ def coop_invite_kb() -> ReplyKeyboardMarkup:
     """Keyboard for inviting the second player."""
 
     rows = [
-        [KeyboardButton("Пригласить из контактов", request_contact=True)],
+        [
+            KeyboardButton(
+                "Пригласить из контактов",
+                request_user=KeyboardButtonRequestUser(
+                    request_id=COOP_INVITE_REQUEST_ID,
+                    user_is_bot=False,
+                ),
+            )
+        ],
         [KeyboardButton("Создать ссылку")],
     ]
     return ReplyKeyboardMarkup(rows, resize_keyboard=True, one_time_keyboard=True)


### PR DESCRIPTION
## Summary
- request second-player invites through Telegram's user picker instead of sharing raw contacts
- handle user_shared payloads in the cooperative invite stage while keeping the share-link fallback

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9c4b4f8b88326a47df4803c854002