### PR TITLE
Fix cooperative invite keyboard to request users

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -296,7 +296,7 @@ def coop_invite_kb() -> ReplyKeyboardMarkup:
         [
             KeyboardButton(
                 "Пригласить из контактов",
-                request_user=KeyboardButtonRequestUser(
+                request_users=KeyboardButtonRequestUser(
                     request_id=COOP_INVITE_REQUEST_ID,
                     user_is_bot=False,
                 ),


### PR DESCRIPTION
## Summary
- update the cooperative invitation keyboard button to pass the request object via the `request_users` parameter while keeping the compatibility alias

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68c9c8c73f448326b92df7761c2288b4