### PR TITLE
Handle shared users in coop invite

### DIFF
--- a/tests/test_coop_game.py
+++ b/tests/test_coop_game.py
@@ -303,7 +303,13 @@ def test_invite_stage_sends_users_shared_invitation(monkeypatch):
     update = SimpleNamespace(
         effective_user=SimpleNamespace(id=1),
         message=SimpleNamespace(
-            users_shared=SimpleNamespace(user_ids=[888]),
+            users_shared=SimpleNamespace(
+                user_ids=[888],
+                users=[
+                    SimpleNamespace(user_id=999),
+                    SimpleNamespace(user_id=None),
+                ],
+            ),
             user_shared=None,
             contact=None,
             text=None,
@@ -314,9 +320,10 @@ def test_invite_stage_sends_users_shared_invitation(monkeypatch):
     asyncio.run(hco.msg_coop(update, context))
 
     assert join_calls == ["s1"]
-    assert bot.sent and bot.sent[0][0] == 888
+    assert bot.sent and bot.sent[0][0] == 999
     assert bot.sent[0][2].session == "s1"
     assert replies and "Приглашение отправлено" in replies[0][0]
+    assert all("нет Telegram" not in text for text, _ in replies)
     assert context.user_data["coop_pending"]["stage"] == "invite"
 
 


### PR DESCRIPTION
## Summary
- allow the cooperative invite flow to read the first available SharedUser id when Telegram shares contacts
- keep the existing fallbacks for user_ids, user_shared, and contact while preventing false "no account" warnings
- cover the SharedUser payload in the invite-stage test to ensure invitations are delivered without unnecessary alerts

## Testing
- PYTHONPATH=. pytest tests/test_coop_game.py

------
https://chatgpt.com/codex/tasks/task_e_68ca5c4c31488326b53ef3d5f5794cef