### PR TITLE
Send coop invite link without inline button

### DIFF
--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -17,8 +17,6 @@ from telegram import (
     ReplyKeyboardRemove,
     Chat,
     User,
-    InlineKeyboardButton,
-    InlineKeyboardMarkup,
 )
 from telegram.ext import ContextTypes
 from telegram.error import TelegramError
@@ -907,12 +905,8 @@ async def msg_coop(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 )
                 return
             invite_link = f"https://t.me/{bot_username}?start=coop_{session_id}"
-            markup = InlineKeyboardMarkup(
-                [[InlineKeyboardButton("🙋 Присоединиться", url=invite_link)]]
-            )
             await message.reply_text(
-                f"Поделитесь этой ссылкой с другом:\n{invite_link}",
-                reply_markup=markup,
+                f"Поделитесь этой ссылкой с другом:\n{invite_link}"
             )
             return
 

--- a/tests/test_coop_game.py
+++ b/tests/test_coop_game.py
@@ -527,7 +527,8 @@ def test_invite_stage_generates_link(monkeypatch):
     assert replies
     response_text, markup = replies[0]
     assert expected_link in response_text
-    assert markup.inline_keyboard[0][0].url == expected_link
+    assert "Поделитесь этой ссылкой" in response_text
+    assert markup is None
     assert context.user_data["coop_pending"]["stage"] == "invite"
 
 


### PR DESCRIPTION
## Summary
- stop attaching an inline button to cooperative invite links and send the URL in plain text
- adjust the cooperative tests to expect text-only invite messages

## Testing
- pytest tests/test_coop_game.py

------
https://chatgpt.com/codex/tasks/task_e_68caa89d751c8326836ec17ff5d9ee5e