### PR TITLE
Skip coop scoreboard when finishing

### DIFF
--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -608,6 +608,8 @@ async def _next_turn(
             session.current_pair = None
         session.turn_index = 0
 
+    pairs_left = bool(session.remaining_pairs)
+
     if score_changed:
         logger.debug(
             "Delaying cooperative scoreboard for session %s by %s seconds",
@@ -615,6 +617,9 @@ async def _next_turn(
             TURN_TRANSITION_DELAY,
         )
         await asyncio.sleep(TURN_TRANSITION_DELAY)
+        if not pairs_left:
+            await _finish_game(context, session)
+            return
         await _broadcast_score(context, session)
         await asyncio.sleep(POST_SCOREBOARD_DELAY)
     else:
@@ -629,11 +634,7 @@ async def _next_turn(
         await _finish_game(context, session)
         return
 
-    if session.remaining_pairs:
-        await _ask_current_pair(context, session)
-        return
-
-    await _finish_game(context, session)
+    await _ask_current_pair(context, session)
 
 
 async def _finish_game(context: ContextTypes.DEFAULT_TYPE, session: CoopSession) -> None:

--- a/tests/test_dummy_coop.py
+++ b/tests/test_dummy_coop.py
@@ -401,16 +401,16 @@ def test_bot_takes_turn_after_second_player(monkeypatch):
         for _, text, *_ in bot.sent
         if text and text.startswith("📊 <b>Текущий счёт</b>")
     ]
-    players_total = sum(session.player_stats.values())
-    expected_remaining = max(session.total_pairs - (players_total + session.bot_stats), 0)
-    team_label = hco._format_team_label(session)
-    expected_score = (
-        "📊 <b>Текущий счёт</b>\n"
-        f"🤝 <b>Команда</b> ({escape(team_label)}) — <b>{players_total}</b>\n"
-        f"🤖 <b>Бот-противник</b> — <b>{session.bot_stats}</b>\n"
-        f"{hco._format_remaining_questions_line(expected_remaining)}"
-    )
-    assert expected_score in score_messages
+    assert score_messages, "scoreboard should be broadcast after the first correct answer"
+
+    assert any(
+        "Осталось <b>" in message for message in score_messages
+    ), "intermediate scoreboard should reflect pending questions"
+
+    final_remaining_line = hco._format_remaining_questions_line(0)
+    assert all(
+        final_remaining_line not in message for message in score_messages
+    ), "final scoreboard should be omitted when no pairs remain"
 
     assert session.turn_index == 0
     assert session.current_pair is None


### PR DESCRIPTION
## Summary
- stop broadcasting the cooperative scoreboard when no question pairs remain and finish the match immediately after the post-turn delay
- keep the transition pacing the same while ensuring the final message is only sent once for both human and bot answers
- adjust the dummy cooperative test expectations so the final scoreboard message is no longer required once the queue is exhausted

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cadb2ffb1c83268bea2ce9d6670484