### PR TITLE
Add robot emoji to coop bot team names

### DIFF
--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -53,8 +53,8 @@ BOT_ATLAS_ID = "bot:atlas"
 BOT_GLOBUS_ID = "bot:globus"
 BOT_TEAM_ORDER = [BOT_ATLAS_ID, BOT_GLOBUS_ID]
 BOT_TEAM_NAMES = {
-    BOT_ATLAS_ID: "Бот Атлас",
-    BOT_GLOBUS_ID: "Бот Глобус",
+    BOT_ATLAS_ID: "🤖 Бот Атлас",
+    BOT_GLOBUS_ID: "🤖 Бот Глобус",
 }
 
 # Probability of the bot answering correctly depending on the difficulty.


### PR DESCRIPTION
## Summary
- update cooperative bot team names to include the robot emoji
- ensure scoreboard and other member.name outputs reuse the new emoji-enhanced names without duplication

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb0499024c8326ae5532c82fa3270e