### PR TITLE
Format coop question header

### DIFF
--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -385,7 +385,8 @@ async def _ask_current_pair(context: ContextTypes.DEFAULT_TYPE, session: CoopSes
     current_participant = session.players[session.turn_index]
     prompt = session.current_pair["prompt"]
     participant_name = _get_participant_display_name(session, current_participant)
-    question_text = f"<b>{escape(participant_name)}</b>\n\n{prompt}"
+    participant_html = escape(participant_name)
+    question_text = f"Вопрос игроку <b>{participant_html}</b>:\n\n{prompt}"
 
     if current_participant == DUMMY_PLAYER_ID:
         recipients = [pid for pid in session.players if pid != DUMMY_PLAYER_ID]

--- a/tests/test_coop_game.py
+++ b/tests/test_coop_game.py
@@ -69,10 +69,10 @@ def _setup_session(monkeypatch, continent=None):
 def _split_question_text(text):
     if not text:
         return None, text
-    if "\n\n" in text:
-        header, rest = text.split("\n\n", 1)
-        if header.startswith("<b>") and header.endswith("</b>"):
-            return header, rest
+    parts = text.split("\n\n", 1)
+    if len(parts) == 2:
+        header, rest = parts
+        return header, rest
     return None, text
 
 
@@ -630,7 +630,9 @@ def test_question_stays_on_wrong_answer(monkeypatch):
     question_messages = [entry for entry in bot.sent if _split_question_text(entry[1])[1] == prompt]
     assert len(question_messages) == len(session.players)
     assert {chat_id for chat_id, *_ in question_messages} == set(session.player_chats.values())
-    assert {_split_question_text(text)[0] for _, text, _ in question_messages} == {"<b>A</b>"}
+    assert {_split_question_text(text)[0] for _, text, _ in question_messages} == {
+        "Вопрос игроку <b>A</b>:"
+    }
 
     initial_len = len(bot.sent)
     asyncio.run(hco._next_turn(context, session, False))
@@ -640,7 +642,9 @@ def test_question_stays_on_wrong_answer(monkeypatch):
     assert len(new_messages) == len(session.players)
     assert all(_split_question_text(text)[1] == prompt for _, text, _ in new_messages)
     assert {chat_id for chat_id, *_ in new_messages} == set(session.player_chats.values())
-    assert {_split_question_text(text)[0] for _, text, _ in new_messages} == {"<b>B</b>"}
+    assert {_split_question_text(text)[0] for _, text, _ in new_messages} == {
+        "Вопрос игроку <b>B</b>:"
+    }
     assert len(session.remaining_pairs) > 0
     assert calls.count(session.players[0]) == 1
     assert calls.count(session.players[1]) == 1


### PR DESCRIPTION
## Summary
- update cooperative question messages to prefix prompts with "Вопрос игроку" and bolded player names
- adjust coop unit tests to parse the new header format and assert bot prompts use it as well

## Testing
- pytest tests/test_coop_game.py tests/test_dummy_coop.py

------
https://chatgpt.com/codex/tasks/task_e_68cb04e0bb8c83268547d4c90cdfa208