### PR TITLE
Remove percentages from coop difficulty labels

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -349,19 +349,19 @@ def coop_difficulty_kb(session_id: str, player_id: int) -> InlineKeyboardMarkup:
     rows = [
         [
             InlineKeyboardButton(
-                "🟢 Лёгкий · 70 %",
+                "🟢 Лёгкий",
                 callback_data=f"coop:diff:{session_id}:{player_id}:easy",
             )
         ],
         [
             InlineKeyboardButton(
-                "🟡 Средний · 80 %",
+                "🟡 Средний",
                 callback_data=f"coop:diff:{session_id}:{player_id}:medium",
             )
         ],
         [
             InlineKeyboardButton(
-                "🔴 Продвинутый · 90 %",
+                "🔴 Продвинутый",
                 callback_data=f"coop:diff:{session_id}:{player_id}:hard",
             )
         ],


### PR DESCRIPTION
## Summary
- update cooperative difficulty keyboard labels to drop percent indicators

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb0a1cd1908326ad7710b8a7ddc2df