### PR TITLE
Remove redundant bot success broadcast

### DIFF
--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -407,17 +407,6 @@ async def _handle_bot_turn(
     if bot_correct:
         await _broadcast_correct_answer(context, session, bot_name)
         await asyncio.sleep(CORRECT_ANSWER_DELAY)
-        summary_text = f"Бот отвечает верно. ({bot_name})"
-        for pid in session.players:
-            chat_id = session.player_chats.get(pid)
-            if not chat_id:
-                continue
-            try:
-                await context.bot.send_message(
-                    chat_id, summary_text, parse_mode="HTML"
-                )
-            except (TelegramError, HTTPError) as e:
-                logger.warning("Failed to notify about bot move: %s", e)
     else:
         pair = session.current_pair if isinstance(session.current_pair, dict) else None
         bot_answer: str | None = None

--- a/tests/test_coop_game.py
+++ b/tests/test_coop_game.py
@@ -836,7 +836,7 @@ def test_more_fact(monkeypatch):
     asyncio.run(hco.cb_coop(update, context))
 
     msg_entry = session.fact_message_ids[1]
-    msg_id = msg_entry[0] if isinstance(msg_entry, list) else msg_entry
+    msg_id = msg_entry[-1] if isinstance(msg_entry, list) else msg_entry
     caption = next(e[1] for e in bot.sent if e[1] and "Франция" in e[1])
 
     q_more = SimpleNamespace(
@@ -854,5 +854,13 @@ def test_more_fact(monkeypatch):
     )
     update_more = SimpleNamespace(callback_query=q_more, effective_user=SimpleNamespace(id=1))
     asyncio.run(hco.cb_coop(update_more, context))
-    assert mock_llm.await_count == 1
+    assert q_more.edit_message_caption.await_count == 1
+    caption_args = q_more.edit_message_caption.await_args
+    if caption_args:
+        args, kwargs = caption_args
+        caption_text = ""
+        if args:
+            caption_text = args[0]
+        caption_text = kwargs.get("caption", caption_text)
+        assert "Еще один факт: new" in caption_text
     assert 1 not in session.fact_message_ids

--- a/tests/test_dummy_coop.py
+++ b/tests/test_dummy_coop.py
@@ -13,6 +13,12 @@ def _split_question_text(text: str | None) -> tuple[str | None, str | None]:
     return None, text
 
 
+def _entry_text(entry):
+    if isinstance(entry, tuple) and len(entry) >= 2:
+        return entry[1] or ""
+    return ""
+
+
 def test_admin_button_visible_only_for_admin(monkeypatch):
     monkeypatch.setenv("ADMIN_ID", "1")
     monkeypatch.setenv("TELEGRAM_BOT_TOKEN", "x")
@@ -229,7 +235,7 @@ def test_cmd_coop_test_spawns_dummy_partner(monkeypatch):
         if body == question_prompt and header
     ]
     assert f"Вопрос игроку <b>🤖 Бот Атлас</b>:" in bot_question_headers
-    assert any("Бот отвечает верно" in (entry[1] or "") for entry in bot.sent)
+    assert any("отвечает верно" in _entry_text(entry) for entry in bot.sent)
     final_text = bot.sent[-1][1]
     assert final_text.startswith("🏁 <b>Игра завершена!</b>")
     assert "🤖 <b>Команда ботов" in final_text
@@ -391,7 +397,7 @@ def test_bot_takes_turn_after_second_player(monkeypatch):
 
     asyncio.run(hco._next_turn(context, session, True))
 
-    bot_messages = [msg for msg in bot.sent if "Бот отвечает" in msg[1]]
+    bot_messages = [msg for msg in bot.sent if "отвечает верно" in _entry_text(msg)]
     assert len(bot_messages) == len(session.players)
     assert all("верно" in text for _, text, *_ in bot_messages)
     assert session.bot_stats >= 1


### PR DESCRIPTION
## Summary
- remove the extra text broadcast for correct bot answers in `_handle_bot_turn`
- adjust cooperative tests to look for the new success wording and to validate fact updates via caption edits

## Testing
- `python - <<'PY'
import os
os.environ.setdefault('TELEGRAM_BOT_TOKEN','dummy')
import app
import pytest, sys
sys.exit(pytest.main(['tests/test_coop_game.py','tests/test_dummy_coop.py','tests/test_coop_cancel.py']))
PY`


------
https://chatgpt.com/codex/tasks/task_e_68cb17c510488326bd86f5ea7b9fff02