### PR TITLE
Add cooperative rematch flow with saved settings

### DIFF
--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -411,11 +411,11 @@ def coop_fact_more_kb(session_id: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(rows)
 
 
-def coop_finish_kb() -> InlineKeyboardMarkup:
+def coop_finish_kb(session_id: str) -> InlineKeyboardMarkup:
     """Keyboard shown after a cooperative match finishes."""
 
     rows = [
-        [InlineKeyboardButton("Сыграть еще раз", callback_data="menu:coop")],
+        [InlineKeyboardButton("Сыграть еще раз", callback_data=f"coop:rematch:{session_id}")],
         [InlineKeyboardButton("В меню", callback_data="menu:main")],
     ]
     return InlineKeyboardMarkup(rows)


### PR DESCRIPTION
## Summary
- preserve cooperative session details on finish so they can be reused for rematches
- update the finish keyboard to trigger a coop rematch callback with the original session id
- implement rematch handling that recreates the session, supports admin test mode, and reopens continent selection for players

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb17dd9d548326b04f18ff4e71cf2e