### PR TITLE
Update coop finish summary formatting

### DIFF
--- a/tests/test_coop_game.py
+++ b/tests/test_coop_game.py
@@ -855,4 +855,8 @@ def test_more_fact(monkeypatch):
     update_more = SimpleNamespace(callback_query=q_more, effective_user=SimpleNamespace(id=1))
     asyncio.run(hco.cb_coop(update_more, context))
     assert mock_llm.await_count == 1
-    assert 1 not in session.fact_message_ids
+    holder = session.fact_message_ids.get(1, [])
+    if isinstance(holder, list):
+        assert msg_id not in holder
+    else:
+        assert holder != msg_id

--- a/tests/test_dummy_coop.py
+++ b/tests/test_dummy_coop.py
@@ -232,7 +232,7 @@ def test_cmd_coop_test_spawns_dummy_partner(monkeypatch):
     assert any("Бот отвечает верно" in (entry[1] or "") for entry in bot.sent)
     final_text = bot.sent[-1][1]
     assert final_text.startswith("🏁 <b>Игра завершена!</b>")
-    assert "🤖 <b>Команда ботов" in final_text
+    assert "<b>Команда Бот Атлас и Бот Глобус</b>" in final_text
     assert all(chat_id is not None for chat_id, *_ in bot.sent)
     assert session.player_stats.get(hco.DUMMY_PLAYER_ID, 0) == 0
     assert not sessions


### PR DESCRIPTION
## Summary
- format the cooperative finish message as "Команда {имя1} и {имя2}" and show bot totals without emojis while preserving fact callbacks after a match
- keep finished sessions available for "Еще один факт" requests and refresh the cache after servicing callbacks
- update cooperative tests to align with the new team naming and fact-message tracking

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68cb17d622bc83269d738adfa6a04304