### PR TITLE
Update coop finish messaging and post-game handling

### DIFF
--- a/tests/test_dummy_coop.py
+++ b/tests/test_dummy_coop.py
@@ -238,10 +238,11 @@ def test_cmd_coop_test_spawns_dummy_partner(monkeypatch):
     assert any("отвечает верно" in _entry_text(entry) for entry in bot.sent)
     final_text = bot.sent[-1][1]
     assert final_text.startswith("🏁 <b>Игра завершена!</b>")
-    assert "🤖 <b>Команда ботов" in final_text
+    assert "<b>Команда Бота Атлас и Бота Глобус</b>" in final_text
     assert all(chat_id is not None for chat_id, *_ in bot.sent)
     assert session.player_stats.get(hco.DUMMY_PLAYER_ID, 0) == 0
-    assert not sessions
+    assert getattr(session, "finished", False)
+    assert session.fact_message_ids
 
 
 def test_scoreboard_format_for_single_player(monkeypatch):


### PR DESCRIPTION
## Summary
- reformat the cooperative final score output to use explicit team names without legacy lines
- retain finished sessions while fact messages are pending so "more fact" callbacks keep working and clean up once processed
- adjust the dummy cooperative test expectations to the new finish message and session lifecycle

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cb1c0f3bc88326ae55208ff31b0132