### PR TITLE
Store metadata for cooperative fact messages

### DIFF
--- a/bot/state.py
+++ b/bot/state.py
@@ -156,7 +156,7 @@ class CoopSession:
     turn_order: List[int | str] = field(default_factory=list)
     bot_turn_index: int = 0
     total_pairs: int = 0
-    fact_message_ids: Dict[int, int] = field(default_factory=dict)
+    fact_message_ids: Dict[int, Dict[str, Any]] = field(default_factory=dict)
     fact_subject: str | None = None
     fact_text: str | None = None
 

--- a/tests/test_coop_game.py
+++ b/tests/test_coop_game.py
@@ -830,8 +830,8 @@ def test_more_fact(monkeypatch):
     update = SimpleNamespace(callback_query=callback, effective_user=SimpleNamespace(id=1))
     asyncio.run(hco.cb_coop(update, context))
 
-    msg_entry = session.fact_message_ids[1]
-    msg_id = msg_entry[-1] if isinstance(msg_entry, list) else msg_entry
+    msg_id, metadata = next(iter(session.fact_message_ids.items()))
+    assert metadata["owner"] == 1
     caption = next(e[1] for e in bot.sent if e[1] and "Франция" in e[1])
 
     q_more = SimpleNamespace(
@@ -858,4 +858,4 @@ def test_more_fact(monkeypatch):
             caption_text = args[0]
         caption_text = kwargs.get("caption", caption_text)
         assert "Еще один факт: new" in caption_text
-    assert 1 not in session.fact_message_ids
+    assert msg_id not in session.fact_message_ids


### PR DESCRIPTION
## Summary
- store cooperative fact message entries as message-id keyed metadata with owner and fact details
- update extra-fact callback to consume the stored metadata and clean up processed messages
- adjust cooperative tests to assert against the new storage format

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cbe04615c8832691582e8a13d74c8b