### PR TITLE
Adjust cooperative scoreboard HTML formatting

### DIFF
--- a/bot/handlers_coop.py
+++ b/bot/handlers_coop.py
@@ -706,8 +706,8 @@ async def _broadcast_score(
 
     text_lines = [
         "📊 <b>Текущий счёт</b>",
-        f"🤝 <b>Команда {team_label_html}</b> — <b>{players_total}</b>",
-        f"🤖 <b>{bot_label_html}</b> — <b>{session.bot_team_score}</b>",
+        f"🤝 Команда {team_label_html} — <b>{players_total}</b>",
+        f"🤖 {bot_label_html} — <b>{session.bot_team_score}</b>",
     ]
     text_lines.append(remaining_line)
 
@@ -804,7 +804,7 @@ async def _finish_game(context: ContextTypes.DEFAULT_TYPE, session: CoopSession)
     team_label = _format_team_label(session)
     team_label_html = escape(team_label)
     players_total = sum(session.player_stats.values())
-    team_line = f"🤝 <b>Команда {team_label_html}</b> — <b>{players_total}</b>"
+    team_line = f"🤝 Команда {team_label_html} — <b>{players_total}</b>"
     bot_names: list[str] = []
     for member in session.bot_team:
         cleaned = _strip_bot_emoji(member.name)
@@ -822,13 +822,11 @@ async def _finish_game(context: ContextTypes.DEFAULT_TYPE, session: CoopSession)
     else:
         bot_label = "Команда " + ", ".join(bot_names[:-1]) + f" и {bot_names[-1]}"
     bot_label_html = escape(bot_label)
-    bot_line = f"<b>{bot_label_html}</b> — <b>{session.bot_team_score}</b>"
+    bot_line = f"{bot_label_html} — <b>{session.bot_team_score}</b>"
     if players_total > session.bot_team_score:
-        result_line = f"🎉 <b>Команда {team_label_html}</b> побеждает!"
+        result_line = f"🎉 Команда {team_label_html} <b>побеждает!</b>"
     elif players_total < session.bot_team_score:
-        result_line = (
-            f"🤖 <b>{bot_label_html}</b> одерживает победу!"
-        )
+        result_line = f"🤖 {bot_label_html} <b>одерживает победу!</b>"
     else:
         result_line = "🤝 <b>Ничья — отличная игра!</b>"
 

--- a/tests/test_coop_game.py
+++ b/tests/test_coop_game.py
@@ -732,13 +732,13 @@ def test_score_broadcast_includes_team_total(monkeypatch):
     assert score_messages
     scoreboard_text = score_messages[-1]
     assert (
-        f"🤝 <b>Команда {escape(team_label)}</b> — <b>{players_total}</b>"
+        f"🤝 Команда {escape(team_label)} — <b>{players_total}</b>"
         in scoreboard_text
     )
     hco._ensure_turn_setup(session)
     bot_label = hco._format_bot_team_score_label(session)
     assert (
-        f"🤖 <b>{escape(bot_label)}</b> — <b>{session.bot_stats}</b>" in scoreboard_text
+        f"🤖 {escape(bot_label)} — <b>{session.bot_stats}</b>" in scoreboard_text
     )
     remaining_line = hco._format_remaining_questions_line(expected_remaining)
     assert remaining_line in scoreboard_text

--- a/tests/test_dummy_coop.py
+++ b/tests/test_dummy_coop.py
@@ -238,7 +238,7 @@ def test_cmd_coop_test_spawns_dummy_partner(monkeypatch):
     assert any("отвечает верно" in _entry_text(entry) for entry in bot.sent)
     final_text = bot.sent[-1][1]
     assert final_text.startswith("🏁 <b>Игра завершена!</b>")
-    assert "<b>Команда Бота Атлас и Бота Глобус</b>" in final_text
+    assert "Команда Бота Атлас и Бота Глобус — <b>" in final_text
     assert all(chat_id is not None for chat_id, *_ in bot.sent)
     assert session.player_stats.get(hco.DUMMY_PLAYER_ID, 0) == 0
     assert getattr(session, "finished", False)
@@ -308,10 +308,10 @@ def test_scoreboard_format_for_single_player(monkeypatch):
     scoreboard_text = score_messages[-1]
 
     assert (
-        "🤝 <b>Команда Тестер и Бот-помощник</b>" in scoreboard_text
+        "🤝 Команда Тестер и Бот-помощник — <b>" in scoreboard_text
     ), "player heading should not contain parentheses"
     assert (
-        "🤖 <b>Команда Бот Атлас и Бот Глобус</b>" in scoreboard_text
+        "🤖 Команда Бот Атлас и Бот Глобус — <b>" in scoreboard_text
     ), "bot heading should list both bot names without emoji"
     assert "•" not in scoreboard_text, "per-bot breakdown should be removed"
 


### PR DESCRIPTION
## Summary
- remove bold tags around the "Команда …" fragments in cooperative score updates and final summaries while keeping numeric values emphasized
- update cooperative tests to match the new HTML output and continue verifying escaping

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc0f9eac688326b52a1670a603d363