### PR TITLE
Refine coop bot team emoji placement

### DIFF
--- a/tests/test_dummy_coop.py
+++ b/tests/test_dummy_coop.py
@@ -238,7 +238,7 @@ def test_cmd_coop_test_spawns_dummy_partner(monkeypatch):
     assert any("отвечает верно" in _entry_text(entry) for entry in bot.sent)
     final_text = bot.sent[-1][1]
     assert final_text.startswith("🏁 <b>Игра завершена!</b>")
-    assert "Команда Бота Атлас и Бота Глобус — <b>" in final_text
+    assert "🤖 Команда Бота Атласа и Бота Глобуса — <b>" in final_text
     assert all(chat_id is not None for chat_id, *_ in bot.sent)
     assert session.player_stats.get(hco.DUMMY_PLAYER_ID, 0) == 0
     assert getattr(session, "finished", False)
@@ -311,7 +311,7 @@ def test_scoreboard_format_for_single_player(monkeypatch):
         "🤝 Команда Тестер и Бот-помощник — <b>" in scoreboard_text
     ), "player heading should not contain parentheses"
     assert (
-        "🤖 Команда Бот Атлас и Бот Глобус — <b>" in scoreboard_text
+        "🤖 Команда Бота Атласа и Бота Глобуса — <b>" in scoreboard_text
     ), "bot heading should list both bot names without emoji"
     assert "•" not in scoreboard_text, "per-bot breakdown should be removed"
 


### PR DESCRIPTION
## Summary
- add explicit genitive bot names to reuse when formatting cooperative team labels
- ensure the bot scoreboard lines use a single leading robot emoji and share the formatting helper
- update the dummy cooperative tests to cover the revised formatting

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc390c19748326a43cba3c2c2b2c50