### PR TITLE
Add prefix support to fact more keyboard

### DIFF
--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -227,7 +227,7 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                             q.message.chat_id,
                             flag_file,
                             caption=fact_msg,
-                            reply_markup=fact_more_kb(),
+                            reply_markup=fact_more_kb(prefix="cards"),
                         )
                 except (TelegramError, HTTPError) as e:
                     logger.warning("Failed to send flag image: %s", e)
@@ -236,7 +236,7 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                     msg = await context.bot.send_message(
                         q.message.chat_id,
                         fact_msg,
-                        reply_markup=fact_more_kb(),
+                        reply_markup=fact_more_kb(prefix="cards"),
                     )
                 except (TelegramError, HTTPError) as e:
                     logger.warning("Failed to send card feedback: %s", e)
@@ -321,7 +321,7 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                         q.message.chat_id,
                         flag_file,
                         caption=fact_msg,
-                        reply_markup=fact_more_kb(),
+                        reply_markup=fact_more_kb(prefix="cards"),
                     )
             except (TelegramError, HTTPError) as e:
                 logger.warning("Failed to send flag image: %s", e)
@@ -330,7 +330,7 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 msg = await context.bot.send_message(
                     q.message.chat_id,
                     fact_msg,
-                    reply_markup=fact_more_kb(),
+                    reply_markup=fact_more_kb(prefix="cards"),
                 )
             except (TelegramError, HTTPError) as e:
                 logger.warning("Failed to send card feedback: %s", e)

--- a/bot/handlers_test.py
+++ b/bot/handlers_test.py
@@ -192,7 +192,7 @@ async def cb_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                             q.message.chat_id,
                             flag_file,
                             caption=fact_msg,
-                            reply_markup=fact_more_kb(),
+                            reply_markup=fact_more_kb(prefix="test"),
                         )
                 except (TelegramError, HTTPError) as e:
                     logger.warning("Failed to send flag image: %s", e)
@@ -201,7 +201,7 @@ async def cb_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                     msg = await context.bot.send_message(
                         q.message.chat_id,
                         fact_msg,
-                        reply_markup=fact_more_kb(),
+                        reply_markup=fact_more_kb(prefix="test"),
                     )
                 except (TelegramError, HTTPError) as e:
                     logger.warning("Failed to send card feedback: %s", e)
@@ -275,7 +275,7 @@ async def cb_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                         q.message.chat_id,
                         flag_file,
                         caption=fact_msg,
-                        reply_markup=fact_more_kb(),
+                        reply_markup=fact_more_kb(prefix="test"),
                     )
             except (TelegramError, HTTPError) as e:
                 logger.warning("Failed to send flag image: %s", e)
@@ -284,7 +284,7 @@ async def cb_test(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
                 msg = await context.bot.send_message(
                     q.message.chat_id,
                     fact_msg,
-                    reply_markup=fact_more_kb(),
+                    reply_markup=fact_more_kb(prefix="test"),
                 )
             except (TelegramError, HTTPError) as e:
                 logger.warning("Failed to send card feedback: %s", e)

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -206,9 +206,13 @@ def cards_answer_kb(prefix: str = "cards") -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(rows)
 
 
-def fact_more_kb() -> InlineKeyboardMarkup:
-    """Keyboard with a single button to request another fact."""
-    rows = [[InlineKeyboardButton("Еще один факт", callback_data="cards:more_fact")]]
+def fact_more_kb(prefix: str = "cards") -> InlineKeyboardMarkup:
+    """Keyboard with a single button to request another fact.
+
+    ``prefix`` selects the callback namespace so handlers can distinguish
+    between flash-cards and test mode callbacks.
+    """
+    rows = [[InlineKeyboardButton("Еще один факт", callback_data=f"{prefix}:more_fact")]]
     return InlineKeyboardMarkup(rows)
 
 

--- a/tests/test_test_mode_flow.py
+++ b/tests/test_test_mode_flow.py
@@ -87,6 +87,22 @@ def test_full_test_flow(monkeypatch):
         assert session.unknown_set
         assert get_user_stats(context.user_data).to_repeat
 
+        fact_markup = next(
+            (
+                markup
+                for _, _, markup in reversed(bot.sent)
+                if markup
+                and any(
+                    getattr(btn, "callback_data", None) == "test:more_fact"
+                    for row in markup.inline_keyboard
+                    for btn in row
+                    if getattr(btn, "callback_data", None)
+                )
+            ),
+            None,
+        )
+        assert fact_markup is not None, "Fact keyboard with test prefix not found"
+
         # after "Показать ответ" следующий вопрос отправляется автоматически
         current = context.user_data["test_session"].current
         idx = current["options"].index(current["answer"])


### PR DESCRIPTION
## Summary
- allow reusing the fact_more_kb inline keyboard with a configurable prefix
- update card and test handlers to pass their respective namespaces for callbacks
- extend the test mode flow test to assert the fact button uses the test prefix

## Testing
- PYTHONPATH=. pytest tests/test_test_mode_flow.py

------
https://chatgpt.com/codex/tasks/task_e_68cc6033862083269166cfee766ca703