### PR TITLE
Sync coop fact buttons across players

### DIFF
--- a/bot/state.py
+++ b/bot/state.py
@@ -156,6 +156,7 @@ class CoopSession:
     bot_turn_index: int = 0
     total_pairs: int = 0
     fact_message_ids: Dict[int, Dict[str, Any]] = field(default_factory=dict)
+    fact_message_groups: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     fact_subject: str | None = None
     fact_text: str | None = None
 


### PR DESCRIPTION
## Summary
- track cooperative fact messages in groups so both players see the same extra fact update
- edit the fact message in each player chat once a teammate requests another fact and ignore duplicate presses
- expand cooperative tests to cover the shared update flow and guard against duplicate triggers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68cc66fe613483268b60df2ef431528a