### PR TITLE
Fix coop fact tracking by keying with chat and message id

### DIFF
--- a/bot/state.py
+++ b/bot/state.py
@@ -155,7 +155,7 @@ class CoopSession:
     turn_order: List[int | str] = field(default_factory=list)
     bot_turn_index: int = 0
     total_pairs: int = 0
-    fact_message_ids: Dict[int, Dict[str, Any]] = field(default_factory=dict)
+    fact_message_ids: Dict[tuple[int, int], Dict[str, Any]] = field(default_factory=dict)
     fact_message_groups: Dict[str, Dict[str, Any]] = field(default_factory=dict)
     fact_subject: str | None = None
     fact_text: str | None = None


### PR DESCRIPTION
## Summary
- key cooperative fact message metadata by the (chat_id, message_id) tuple and adjust extra fact broadcasting logic to use the new structure
- update cleanup helpers to respect the new metadata keys and continue removing finished groups
- extend the cooperative game tests to cover duplicate message IDs and adapt existing expectations

## Testing
- pytest tests/test_coop_game.py

------
https://chatgpt.com/codex/tasks/task_e_68ce40789aec83269f0be7a4799de0e4