### PR TITLE
Delay cooperative scoreboard until full turn cycle

### DIFF
--- a/bot/state.py
+++ b/bot/state.py
@@ -154,6 +154,7 @@ class CoopSession:
     bot_team_score: int = 0
     turn_order: List[int | str] = field(default_factory=list)
     bot_turn_index: int = 0
+    turns_since_scoreboard: int = 0
     total_pairs: int = 0
     fact_message_ids: Dict[tuple[int, int], Dict[str, Any]] = field(default_factory=dict)
     fact_message_groups: Dict[str, Dict[str, Any]] = field(default_factory=dict)

--- a/tests/test_coop_game.py
+++ b/tests/test_coop_game.py
@@ -736,7 +736,19 @@ def test_world_mode_limit(monkeypatch):
 def test_score_broadcast_includes_team_total(monkeypatch):
     hco, session, context, bot, _ = _setup_session(monkeypatch, continent="Европа")
     asyncio.run(hco._start_game(context, session))
+    hco._ensure_turn_setup(session)
+    order_length = max(len(session.turn_order), 1)
+
     asyncio.run(hco._next_turn(context, session, True))
+    interim_scores = [
+        text
+        for _, text, *_ in bot.sent
+        if text and text.startswith("📊 <b>Текущий счёт</b>")
+    ]
+    assert not interim_scores, "scoreboard should not be broadcast mid-round"
+
+    for _ in range(order_length - 1):
+        asyncio.run(hco._next_turn(context, session, False))
 
     score_messages = [
         text

--- a/tests/test_dummy_coop.py
+++ b/tests/test_dummy_coop.py
@@ -508,16 +508,9 @@ def test_bot_takes_turn_after_second_player(monkeypatch):
         for _, text, *_ in bot.sent
         if text and text.startswith("📊 <b>Текущий счёт</b>")
     ]
-    assert score_messages, "scoreboard should be broadcast after the first correct answer"
-
-    assert any(
-        "Осталось <b>" in message for message in score_messages
-    ), "intermediate scoreboard should reflect pending questions"
-
-    final_remaining_line = hco._format_remaining_questions_line(0)
-    assert all(
-        final_remaining_line not in message for message in score_messages
-    ), "final scoreboard should be omitted when no pairs remain"
+    assert (
+        not score_messages
+    ), "scoreboard should wait for a full round and is skipped when the match ends"
 
     assert session.current_pair is None
     assert session.player_stats == {1: 1, 2: 1}


### PR DESCRIPTION
## Summary
- track cooperative turn progress so the scoreboard only sends after a full rotation
- adjust turn handling to skip scoreboard dispatch when the match is ending and reset the counter on start/finish
- update cooperative tests to expect the deferred scoreboard behaviour

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e169c736088326b6502104fc0be2cc