### PR TITLE
Add subcategory selection and letter input to cards mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -66,7 +66,7 @@ DATA = load_data()
 
 # ===== Keyboards & Handlers =====
 from bot.handlers_menu import cmd_start, cb_menu
-from bot.handlers_cards import cb_cards
+from bot.handlers_cards import cb_cards, msg_cards_letter
 from bot.handlers_sprint import cb_sprint
 from bot.handlers_test import cb_test
 from bot.handlers_coop import (
@@ -120,6 +120,11 @@ application.add_handler(CommandHandler("coop_cancel", cmd_coop_cancel))
 application.add_handler(CommandHandler("coop_test", cmd_coop_test))
 application.add_handler(CommandHandler("stats", cmd_stats))
 application.add_handler(CommandHandler(["quit", "exit"], cmd_quit))
+_card_letter_handler = MessageHandler(
+    filters.TEXT & ~filters.COMMAND, msg_cards_letter
+)
+_card_letter_handler.block = False
+application.add_handler(_card_letter_handler)
 coop_message_filters = (
     (filters.TEXT & ~filters.COMMAND)
     | filters.CONTACT

--- a/bot/handlers_cards.py
+++ b/bot/handlers_cards.py
@@ -3,6 +3,7 @@
 import logging
 import random
 import asyncio
+from collections.abc import Iterable
 
 from telegram import Update
 from telegram.error import TelegramError
@@ -18,13 +19,151 @@ from .keyboards import (
     cards_finish_kb,
     main_menu_kb,
     fact_more_kb,
+    cards_mode_kb,
+    cards_subcategories_kb,
+    cards_preview_kb,
+    continent_kb,
 )
 from .flags import get_country_flag, get_flag_image_path
-from .handlers_menu import WELCOME, ADMIN_ID
+from .handlers_menu import WELCOME, ADMIN_ID, build_country_list_chunks
 from .facts import get_static_fact, generate_llm_fact
 
 
 logger = logging.getLogger(__name__)
+
+
+def select_matching_countries(countries: Iterable[str]) -> set[str]:
+    """Return countries whose capital matches the country name."""
+
+    result: set[str] = set()
+    for country in countries:
+        capital = DATA.capital_by_country.get(country, "")
+        if capital and capital.casefold() == country.casefold():
+            result.add(country)
+    return result
+
+
+def select_countries_by_letter(countries: Iterable[str], letter: str) -> set[str]:
+    """Return countries whose capital starts with the provided ``letter``.
+
+    ``letter`` must consist of a single alphabetic character. Any other input
+    yields an empty result.
+    """
+
+    normalized = letter.strip()
+    if len(normalized) != 1 or not normalized.isalpha():
+        return set()
+
+    normalized = normalized.casefold()
+    result: set[str] = set()
+    for country in countries:
+        capital = DATA.capital_by_country.get(country, "").lstrip()
+        if not capital:
+            continue
+        first_char = capital[0].casefold()
+        if first_char == normalized:
+            result.add(country)
+    return result
+
+
+def select_remaining_countries(
+    countries: Iterable[str], *exclude_groups: Iterable[str]
+) -> set[str]:
+    """Return countries that are not present in ``exclude_groups``."""
+
+    excluded: set[str] = set()
+    for group in exclude_groups:
+        excluded.update(group)
+    return set(countries) - excluded
+
+
+async def _cleanup_preview_messages(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    keep_message_id: int | None,
+) -> None:
+    """Delete previously sent preview chunks leaving ``keep_message_id`` intact."""
+
+    message_ids: list[int] = context.user_data.pop("card_preview_messages", [])
+    context.user_data.pop("card_preview_chunks", None)
+    chat_id = update.effective_chat.id
+    for message_id in message_ids:
+        if keep_message_id is not None and message_id == keep_message_id:
+            continue
+        try:
+            await context.bot.delete_message(chat_id, message_id)
+        except (TelegramError, HTTPError) as exc:
+            logger.debug("Failed to delete preview message %s: %s", message_id, exc)
+
+
+async def _show_preview(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    subset: Iterable[str],
+    title: str,
+    back_action: str,
+    origin_message_id: int | None = None,
+) -> bool:
+    """Display preview list of countries before starting the session."""
+
+    countries = sorted(set(subset))
+    if not countries:
+        return False
+
+    context.user_data["card_subset"] = countries
+    chunks = build_country_list_chunks(countries, title)
+    context.user_data["card_preview_chunks"] = chunks
+    chat_id = update.effective_chat.id
+    message_id = origin_message_id
+    if message_id is None and update.callback_query:
+        message_id = update.callback_query.message.message_id
+    elif message_id is None and update.effective_message:
+        message_id = update.effective_message.message_id
+
+    preview_messages: list[int] = []
+
+    try:
+        if len(chunks) == 1:
+            if message_id is not None:
+                msg = await context.bot.edit_message_text(
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    text=chunks[0],
+                    reply_markup=cards_preview_kb(back_action),
+                )
+                preview_messages.append(msg.message_id)
+            else:
+                msg = await context.bot.send_message(
+                    chat_id,
+                    chunks[0],
+                    reply_markup=cards_preview_kb(back_action),
+                )
+                preview_messages.append(msg.message_id)
+        else:
+            if message_id is not None:
+                msg = await context.bot.edit_message_text(
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    text=chunks[0],
+                )
+                preview_messages.append(msg.message_id)
+            else:
+                msg = await context.bot.send_message(chat_id, chunks[0])
+                preview_messages.append(msg.message_id)
+            for chunk in chunks[1:-1]:
+                sent = await context.bot.send_message(chat_id, chunk)
+                preview_messages.append(sent.message_id)
+            last = await context.bot.send_message(
+                chat_id, chunks[-1], reply_markup=cards_preview_kb(back_action)
+            )
+            preview_messages.append(last.message_id)
+    except (TelegramError, HTTPError) as exc:
+        logger.warning("Failed to display preview list: %s", exc)
+        return False
+
+    context.user_data["card_preview_messages"] = preview_messages
+    context.user_data.pop("card_letter_pending", None)
+    return True
 
 
 async def _next_card(
@@ -112,6 +251,12 @@ async def _finish_session(update: Update, context: ContextTypes.DEFAULT_TYPE) ->
     if not session:
         return
 
+    context.user_data.pop("card_setup", None)
+    context.user_data.pop("card_subset", None)
+    context.user_data.pop("card_letter_pending", None)
+    context.user_data.pop("card_preview_messages", None)
+    context.user_data.pop("card_preview_chunks", None)
+
     logger.debug(
         "Card session finished for user %s: stats=%s unknown=%d",
         session.user_id,
@@ -164,12 +309,20 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
     q = update.callback_query
 
     parts = q.data.split(":")
+    action = parts[1] if len(parts) > 1 else ""
+
     if parts == ["cards", "void"]:
         await q.answer()
         return
-    if parts == ["cards", "menu"]:
+
+    if action == "menu":
         await q.answer()
+        await _cleanup_preview_messages(update, context, q.message.message_id)
         context.user_data.pop("card_session", None)
+        context.user_data.pop("card_setup", None)
+        context.user_data.pop("card_subset", None)
+        context.user_data.pop("card_letter_pending", None)
+        context.user_data.pop("card_prompt_message_id", None)
         try:
             await q.edit_message_text(
                 WELCOME,
@@ -178,6 +331,242 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         except (TelegramError, HTTPError) as e:
             logger.warning("Failed to return to menu: %s", e)
         return
+
+    setup: dict | None = context.user_data.get("card_setup")
+
+    if action == "back":
+        await q.answer()
+        target = parts[2] if len(parts) > 2 else ""
+        await _cleanup_preview_messages(update, context, q.message.message_id)
+        if target == "continent":
+            context.user_data.pop("card_session", None)
+            context.user_data.pop("card_setup", None)
+            context.user_data.pop("card_subset", None)
+            context.user_data.pop("card_letter_pending", None)
+            context.user_data.pop("card_prompt_message_id", None)
+            text = "📘 Флэш-карточки: выбери континент."
+            try:
+                await q.edit_message_text(
+                    text, reply_markup=continent_kb("menu:cards")
+                )
+            except (TelegramError, HTTPError) as exc:
+                logger.warning("Failed to show continent selection: %s", exc)
+            return
+        if not setup:
+            try:
+                await q.edit_message_text(
+                    "Выбор континента не найден. Нажмите /start, чтобы начать заново.",
+                    reply_markup=main_menu_kb(update.effective_user.id == ADMIN_ID),
+                )
+            except (TelegramError, HTTPError) as exc:
+                logger.warning("Failed to handle missing setup: %s", exc)
+            return
+        context.user_data.pop("card_subset", None)
+        context.user_data.pop("card_letter_pending", None)
+        context.user_data.pop("card_prompt_message_id", None)
+        if target == "mode":
+            text = (
+                f"📘 Флэш-карточки — {setup['continent']}.\n"
+                "Выбери, как будем учить столицы."
+            )
+            try:
+                await q.edit_message_text(text, reply_markup=cards_mode_kb())
+            except (TelegramError, HTTPError) as exc:
+                logger.warning("Failed to show mode selection: %s", exc)
+            return
+        if target == "subcategory":
+            text = (
+                f"📘 Флэш-карточки — {setup['continent']}.\n"
+                "Выбери подкатегорию."
+            )
+            try:
+                await q.edit_message_text(
+                    text, reply_markup=cards_subcategories_kb()
+                )
+            except (TelegramError, HTTPError) as exc:
+                logger.warning("Failed to show subcategory selection: %s", exc)
+            return
+        return
+
+    if action == "mode":
+        await q.answer()
+        if not setup:
+            try:
+                await q.edit_message_text(
+                    "Выбор континента не найден. Нажмите /start, чтобы начать заново.",
+                    reply_markup=main_menu_kb(update.effective_user.id == ADMIN_ID),
+                )
+            except (TelegramError, HTTPError) as exc:
+                logger.warning("Failed to handle missing setup: %s", exc)
+            return
+        option = parts[2] if len(parts) > 2 else ""
+        if option == "all":
+            setup["mode"] = "all"
+            setup["subcategory"] = None
+            setup["letter"] = None
+            await _cleanup_preview_messages(update, context, q.message.message_id)
+            context.user_data.pop("card_prompt_message_id", None)
+            subset = setup["countries"]
+            title = (
+                f"{setup['continent']} — все страны ({len(subset)}):\n"
+            )
+            if not await _show_preview(
+                update, context, subset, title, "cards:back:mode"
+            ):
+                try:
+                    await q.edit_message_text(
+                        "Не удалось подготовить список. Попробуйте выбрать другую опцию.",
+                        reply_markup=cards_mode_kb(),
+                    )
+                except (TelegramError, HTTPError) as exc:
+                    logger.warning("Failed to notify preview error: %s", exc)
+            return
+        if option == "subsets":
+            setup["mode"] = "subsets"
+            setup["subcategory"] = None
+            setup["letter"] = None
+            context.user_data.pop("card_subset", None)
+            context.user_data.pop("card_letter_pending", None)
+            context.user_data.pop("card_prompt_message_id", None)
+            await _cleanup_preview_messages(update, context, q.message.message_id)
+            text = (
+                f"📘 Флэш-карточки — {setup['continent']}.\n"
+                "Выбери подкатегорию."
+            )
+            try:
+                await q.edit_message_text(
+                    text, reply_markup=cards_subcategories_kb()
+                )
+            except (TelegramError, HTTPError) as exc:
+                logger.warning("Failed to show subcategory menu: %s", exc)
+            return
+        return
+
+    if action == "sub":
+        await q.answer()
+        if not setup:
+            try:
+                await q.edit_message_text(
+                    "Сначала выберите континент.",
+                    reply_markup=continent_kb("menu:cards"),
+                )
+            except (TelegramError, HTTPError) as exc:
+                logger.warning("Failed to prompt continent selection: %s", exc)
+            return
+        option = parts[2] if len(parts) > 2 else ""
+        setup["mode"] = "subsets"
+        await _cleanup_preview_messages(update, context, q.message.message_id)
+        if option == "matching":
+            setup["subcategory"] = "matching"
+            setup["letter"] = None
+            context.user_data.pop("card_prompt_message_id", None)
+            matches = select_matching_countries(setup["countries"])
+            if not matches:
+                text = (
+                    "Таких стран нет в выбранном континенте."
+                    "\nВыбери другую подкатегорию."
+                )
+                try:
+                    await q.edit_message_text(
+                        text, reply_markup=cards_subcategories_kb()
+                    )
+                except (TelegramError, HTTPError) as exc:
+                    logger.warning("Failed to show empty matching notice: %s", exc)
+                return
+            title = (
+                f"{setup['continent']} — совпадает со страной ({len(matches)}):\n"
+            )
+            if not await _show_preview(
+                update, context, matches, title, "cards:back:subcategory"
+            ):
+                try:
+                    await q.edit_message_text(
+                        "Не удалось показать список. Попробуйте еще раз.",
+                        reply_markup=cards_subcategories_kb(),
+                    )
+                except (TelegramError, HTTPError) as exc:
+                    logger.warning("Failed to notify preview error: %s", exc)
+            return
+        if option == "letter":
+            setup["subcategory"] = "letter"
+            setup["letter"] = None
+            context.user_data["card_letter_pending"] = True
+            context.user_data.pop("card_subset", None)
+            text = (
+                f"📘 Флэш-карточки — {setup['continent']}.\n"
+                "Введите букву, на которую начинается столица."
+            )
+            try:
+                msg = await q.edit_message_text(
+                    text, reply_markup=cards_subcategories_kb()
+                )
+            except (TelegramError, HTTPError) as exc:
+                logger.warning("Failed to prompt for letter: %s", exc)
+            else:
+                context.user_data["card_prompt_message_id"] = msg.message_id
+            return
+        if option == "other":
+            setup["subcategory"] = "other"
+            setup["letter"] = None
+            context.user_data.pop("card_prompt_message_id", None)
+            matches = select_matching_countries(setup["countries"])
+            others = select_remaining_countries(setup["countries"], matches)
+            if not others:
+                text = (
+                    "Все столицы в этом континенте совпадают с названием страны."
+                    "\nВыбери другую подкатегорию."
+                )
+                try:
+                    await q.edit_message_text(
+                        text, reply_markup=cards_subcategories_kb()
+                    )
+                except (TelegramError, HTTPError) as exc:
+                    logger.warning("Failed to show empty other notice: %s", exc)
+                return
+            title = (
+                f"{setup['continent']} — остальные столицы ({len(others)}):\n"
+            )
+            if not await _show_preview(
+                update, context, others, title, "cards:back:subcategory"
+            ):
+                try:
+                    await q.edit_message_text(
+                        "Не удалось показать список. Попробуйте еще раз.",
+                        reply_markup=cards_subcategories_kb(),
+                    )
+                except (TelegramError, HTTPError) as exc:
+                    logger.warning("Failed to notify preview error: %s", exc)
+            return
+        return
+
+    if action == "start":
+        await q.answer()
+        subset: list[str] | None = context.user_data.get("card_subset")
+        if not subset:
+            await q.answer("Список стран пуст. Выберите другую опцию.", show_alert=True)
+            return
+        await _cleanup_preview_messages(update, context, q.message.message_id)
+        continent_filter = None
+        if setup:
+            continent_filter = setup.get("continent_filter")
+        queue = [
+            (country, random.choice(["country_to_capital", "capital_to_country"]))
+            for country in subset
+        ]
+        random.shuffle(queue)
+        if not queue:
+            await q.answer("Список стран пуст. Выберите другую опцию.", show_alert=True)
+            return
+        session = CardSession(
+            user_id=update.effective_user.id,
+            continent_filter=continent_filter,
+            mode="mixed",
+            queue=queue,
+        )
+        context.user_data["card_session"] = session
+        context.user_data.pop("card_letter_pending", None)
+        context.user_data.pop("card_prompt_message_id", None)
+        await _next_card(update, context)
         return
 
     session: CardSession | None = context.user_data.get("card_session")
@@ -376,4 +765,62 @@ async def cb_cards(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
         return
 
     await q.answer()
+
+
+async def msg_cards_letter(update: Update, context: ContextTypes.DEFAULT_TYPE) -> None:
+    """Handle letter input for the "capital by letter" subcategory."""
+
+    if not context.user_data.get("card_letter_pending"):
+        return
+
+    message = update.effective_message
+    text = (message.text or "").strip()
+
+    setup: dict | None = context.user_data.get("card_setup")
+    if not setup:
+        context.user_data.pop("card_letter_pending", None)
+        await message.reply_text(
+            "Настройка карточек не найдена. Вернитесь в меню и выберите режим снова."
+        )
+        return
+
+    if len(text) != 1 or not text.isalpha():
+        await message.reply_text(
+            "Пожалуйста, введите одну букву без цифр и символов."
+        )
+        return
+
+    letter = text.upper()
+    subset = select_countries_by_letter(setup["countries"], text)
+    if not subset:
+        await message.reply_text(
+            "Столиц на эту букву не найдено. Попробуйте другую букву."
+        )
+        return
+
+    prompt_id = context.user_data.get("card_prompt_message_id")
+    keep_id = prompt_id if isinstance(prompt_id, int) else None
+    await _cleanup_preview_messages(update, context, keep_id)
+
+    setup["subcategory"] = "letter"
+    setup["letter"] = letter
+
+    title = (
+        f"{setup['continent']} — столицы на букву {letter} ({len(subset)}):\n"
+    )
+    if not await _show_preview(
+        update,
+        context,
+        subset,
+        title,
+        "cards:back:subcategory",
+        origin_message_id=keep_id,
+    ):
+        await message.reply_text(
+            "Не удалось показать список. Попробуйте выбрать подкатегорию еще раз."
+        )
+        return
+
+    context.user_data["card_letter_pending"] = False
+    context.user_data.pop("card_prompt_message_id", None)
 

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -206,6 +206,54 @@ def cards_answer_kb(prefix: str = "cards") -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(rows)
 
 
+def cards_mode_kb() -> InlineKeyboardMarkup:
+    """Keyboard for selecting the study scope before starting cards."""
+
+    rows = [
+        [InlineKeyboardButton("Учить все", callback_data="cards:mode:all")],
+        [
+            InlineKeyboardButton(
+                "Учить по подкатегориям", callback_data="cards:mode:subsets"
+            )
+        ],
+        [InlineKeyboardButton("Назад", callback_data="cards:back:continent")],
+        [InlineKeyboardButton("В меню", callback_data="cards:menu")],
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
+def cards_subcategories_kb() -> InlineKeyboardMarkup:
+    """Keyboard for selecting a concrete flash-card subcategory."""
+
+    rows = [
+        [
+            InlineKeyboardButton(
+                "Совпадает со страной", callback_data="cards:sub:matching"
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "Столица на выбранную букву", callback_data="cards:sub:letter"
+            )
+        ],
+        [InlineKeyboardButton("Остальные столицы", callback_data="cards:sub:other")],
+        [InlineKeyboardButton("Назад", callback_data="cards:back:mode")],
+        [InlineKeyboardButton("В меню", callback_data="cards:menu")],
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
+def cards_preview_kb(back_action: str) -> InlineKeyboardMarkup:
+    """Keyboard presented during the preview step before launching cards."""
+
+    rows = [
+        [InlineKeyboardButton("Перейти к карточкам", callback_data="cards:start")],
+        [InlineKeyboardButton("Назад", callback_data=back_action)],
+        [InlineKeyboardButton("В меню", callback_data="cards:menu")],
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
 def fact_more_kb(prefix: str = "cards") -> InlineKeyboardMarkup:
     """Keyboard with a single button to request another fact.
 

--- a/tests/test_cards_subcategories.py
+++ b/tests/test_cards_subcategories.py
@@ -1,0 +1,37 @@
+import os
+import sys
+from pathlib import Path
+
+sys.path.append(str(Path(__file__).resolve().parents[1]))
+os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token")
+
+import bot.handlers_cards as hc
+
+
+def test_select_matching_countries_identifies_duplicates():
+    countries = ["Сингапур", "Люксембург", "Испания", "Германия"]
+    result = hc.select_matching_countries(countries)
+    assert result == {"Сингапур", "Люксембург"}
+
+
+def test_select_countries_by_letter_filters_case_insensitively():
+    countries = ["Россия", "Испания", "Сингапур"]
+    result_lower = hc.select_countries_by_letter(countries, "м")
+    result_upper = hc.select_countries_by_letter(countries, "М")
+    assert result_lower == {"Россия", "Испания"}
+    assert result_upper == result_lower
+
+
+def test_select_countries_by_letter_rejects_invalid_input():
+    countries = ["Россия", "Испания"]
+    assert hc.select_countries_by_letter(countries, "1") == set()
+    assert hc.select_countries_by_letter(countries, "москва") == set()
+    assert hc.select_countries_by_letter(countries, "!") == set()
+
+
+def test_select_remaining_countries_excludes_groups():
+    base = {"Сингапур", "Люксембург", "Испания", "Россия", "Германия"}
+    matching = hc.select_matching_countries(base)
+    letter_set = hc.select_countries_by_letter(base, "м")
+    others = hc.select_remaining_countries(base, matching, letter_set)
+    assert others == {"Германия"}


### PR DESCRIPTION
## Summary
- add dedicated keyboards for the flash-card selection stage, subcategory choice, and preview navigation
- rework the cards menu flow to store user selections, generate filtered previews, and support letter-based subsets with text input handling
- register a text handler for letter input and cover the new filtering helpers with unit tests

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68e219fd7dd88326b41cae0ac9af1497