### PR TITLE
Add subcategory selection flow to test mode

### DIFF
--- a/app.py
+++ b/app.py
@@ -68,7 +68,7 @@ DATA = load_data()
 from bot.handlers_menu import cmd_start, cb_menu
 from bot.handlers_cards import cb_cards, msg_cards_letter
 from bot.handlers_sprint import cb_sprint
-from bot.handlers_test import cb_test
+from bot.handlers_test import cb_test, msg_test_letter
 from bot.handlers_coop import (
     cb_coop,
     cmd_coop_capitals,
@@ -125,6 +125,11 @@ _card_letter_handler = MessageHandler(
 )
 _card_letter_handler.block = False
 application.add_handler(_card_letter_handler)
+_test_letter_handler = MessageHandler(
+    filters.TEXT & ~filters.COMMAND, msg_test_letter
+)
+_test_letter_handler.block = False
+application.add_handler(_test_letter_handler)
 coop_message_filters = (
     (filters.TEXT & ~filters.COMMAND)
     | filters.CONTACT

--- a/bot/keyboards.py
+++ b/bot/keyboards.py
@@ -254,6 +254,54 @@ def cards_preview_kb(back_action: str) -> InlineKeyboardMarkup:
     return InlineKeyboardMarkup(rows)
 
 
+def test_mode_kb() -> InlineKeyboardMarkup:
+    """Keyboard for selecting the test scope before preview."""
+
+    rows = [
+        [InlineKeyboardButton("Тестировать все", callback_data="test:mode:all")],
+        [
+            InlineKeyboardButton(
+                "Тестировать по подкатегориям", callback_data="test:mode:subsets"
+            )
+        ],
+        [InlineKeyboardButton("Назад", callback_data="test:back:continent")],
+        [InlineKeyboardButton("В меню", callback_data="test:menu")],
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
+def test_subcategories_kb() -> InlineKeyboardMarkup:
+    """Keyboard for selecting a test subcategory."""
+
+    rows = [
+        [
+            InlineKeyboardButton(
+                "Столица совпадает со страной", callback_data="test:sub:matching"
+            )
+        ],
+        [
+            InlineKeyboardButton(
+                "Столица на выбранную букву", callback_data="test:sub:letter"
+            )
+        ],
+        [InlineKeyboardButton("Остальные столицы", callback_data="test:sub:other")],
+        [InlineKeyboardButton("Назад", callback_data="test:back:mode")],
+        [InlineKeyboardButton("В меню", callback_data="test:menu")],
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
+def test_preview_kb(back_action: str) -> InlineKeyboardMarkup:
+    """Keyboard presented during the preview step before launching test."""
+
+    rows = [
+        [InlineKeyboardButton("Начать тест", callback_data="test:start")],
+        [InlineKeyboardButton("Назад", callback_data=back_action)],
+        [InlineKeyboardButton("В меню", callback_data="test:menu")],
+    ]
+    return InlineKeyboardMarkup(rows)
+
+
 def fact_more_kb(prefix: str = "cards") -> InlineKeyboardMarkup:
     """Keyboard with a single button to request another fact.
 

--- a/bot/subsets.py
+++ b/bot/subsets.py
@@ -1,0 +1,189 @@
+"""Utility helpers shared between training modes for subset selection."""
+
+from __future__ import annotations
+
+import logging
+from collections.abc import Callable, Iterable
+from typing import Optional
+
+from telegram import InlineKeyboardMarkup, Update
+from telegram.error import TelegramError
+from telegram.ext import ContextTypes
+from httpx import HTTPError
+
+try:  # pragma: no cover - safeguard for tests without token
+    from app import DATA
+except RuntimeError:  # pragma: no cover
+    DATA = None  # type: ignore
+
+try:  # pragma: no cover - avoid hard dependency during tests
+    from .handlers_menu import build_country_list_chunks
+except (RuntimeError, ImportError):
+    from .flags import get_country_flag
+
+    def build_country_list_chunks(countries: list[str], title: str) -> list[str]:
+        lines: list[str] = []
+        for country in countries:
+            capital = DATA.capital_by_country.get(country, "") if DATA else ""
+            flag = get_country_flag(country)
+            lines.append(f"{flag} {country} - Столица: {capital}")
+
+        chunks: list[str] = []
+        current = title
+        for line in lines:
+            line_text = f"{line}\n"
+            if len(current) + len(line_text) > 4000:
+                chunks.append(current.rstrip())
+                current = line_text
+            else:
+                current += line_text
+        chunks.append(current.rstrip())
+        return chunks
+
+logger = logging.getLogger(__name__)
+
+
+def select_matching_countries(countries: Iterable[str]) -> set[str]:
+    """Return countries whose capital matches the country name."""
+
+    result: set[str] = set()
+    for country in countries:
+        capital = DATA.capital_by_country.get(country, "") if DATA else ""
+        if capital and capital.casefold() == country.casefold():
+            result.add(country)
+    return result
+
+
+def select_countries_by_letter(countries: Iterable[str], letter: str) -> set[str]:
+    """Return countries whose capital starts with the provided ``letter``."""
+
+    normalized = letter.strip()
+    if len(normalized) != 1 or not normalized.isalpha():
+        return set()
+
+    normalized = normalized.casefold()
+    result: set[str] = set()
+    for country in countries:
+        capital = DATA.capital_by_country.get(country, "").lstrip() if DATA else ""
+        if not capital:
+            continue
+        first_char = capital[0].casefold()
+        if first_char == normalized:
+            result.add(country)
+    return result
+
+
+def select_remaining_countries(
+    countries: Iterable[str], *exclude_groups: Iterable[str]
+) -> set[str]:
+    """Return countries that are not present in ``exclude_groups``."""
+
+    excluded: set[str] = set()
+    for group in exclude_groups:
+        excluded.update(group)
+    return set(countries) - excluded
+
+
+def _prefixed(prefix: str, suffix: str) -> str:
+    return f"{prefix}_{suffix}" if prefix else suffix
+
+
+async def cleanup_preview_messages(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    prefix: str,
+    keep_message_id: Optional[int] = None,
+) -> None:
+    """Delete previously sent preview messages for the given ``prefix``."""
+
+    key_messages = _prefixed(prefix, "preview_messages")
+    key_chunks = _prefixed(prefix, "preview_chunks")
+    message_ids: list[int] = context.user_data.pop(key_messages, [])
+    context.user_data.pop(key_chunks, None)
+    chat_id = update.effective_chat.id
+    for message_id in message_ids:
+        if keep_message_id is not None and message_id == keep_message_id:
+            continue
+        try:
+            await context.bot.delete_message(chat_id, message_id)
+        except (TelegramError, HTTPError) as exc:
+            logger.debug("Failed to delete preview message %s: %s", message_id, exc)
+
+
+async def show_preview(
+    update: Update,
+    context: ContextTypes.DEFAULT_TYPE,
+    subset: Iterable[str],
+    title: str,
+    back_action: str,
+    prefix: str,
+    keyboard_factory: Callable[[str], InlineKeyboardMarkup],
+    origin_message_id: Optional[int] = None,
+) -> bool:
+    """Display preview list of countries before starting the session."""
+
+    countries = sorted(set(subset))
+    if not countries:
+        return False
+
+    subset_key = _prefixed(prefix, "subset")
+    chunks_key = _prefixed(prefix, "preview_chunks")
+    messages_key = _prefixed(prefix, "preview_messages")
+    letter_key = _prefixed(prefix, "letter_pending")
+
+    context.user_data[subset_key] = countries
+    chunks = build_country_list_chunks(countries, title)
+    context.user_data[chunks_key] = chunks
+
+    chat_id = update.effective_chat.id
+    message_id = origin_message_id
+    if message_id is None and update.callback_query:
+        message_id = update.callback_query.message.message_id
+    elif message_id is None and update.effective_message:
+        message_id = update.effective_message.message_id
+
+    preview_messages: list[int] = []
+
+    try:
+        if len(chunks) == 1:
+            markup = keyboard_factory(back_action)
+            if message_id is not None:
+                msg = await context.bot.edit_message_text(
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    text=chunks[0],
+                    reply_markup=markup,
+                )
+                preview_messages.append(msg.message_id)
+            else:
+                msg = await context.bot.send_message(
+                    chat_id,
+                    chunks[0],
+                    reply_markup=markup,
+                )
+                preview_messages.append(msg.message_id)
+        else:
+            if message_id is not None:
+                msg = await context.bot.edit_message_text(
+                    chat_id=chat_id,
+                    message_id=message_id,
+                    text=chunks[0],
+                )
+                preview_messages.append(msg.message_id)
+            else:
+                msg = await context.bot.send_message(chat_id, chunks[0])
+                preview_messages.append(msg.message_id)
+            for chunk in chunks[1:-1]:
+                sent = await context.bot.send_message(chat_id, chunk)
+                preview_messages.append(sent.message_id)
+            last = await context.bot.send_message(
+                chat_id, chunks[-1], reply_markup=keyboard_factory(back_action)
+            )
+            preview_messages.append(last.message_id)
+    except (TelegramError, HTTPError) as exc:
+        logger.warning("Failed to display preview list: %s", exc)
+        return False
+
+    context.user_data[messages_key] = preview_messages
+    context.user_data.pop(letter_key, None)
+    return True

--- a/tests/test_cards_subcategories.py
+++ b/tests/test_cards_subcategories.py
@@ -5,33 +5,37 @@ from pathlib import Path
 sys.path.append(str(Path(__file__).resolve().parents[1]))
 os.environ.setdefault("TELEGRAM_BOT_TOKEN", "test-token")
 
-import bot.handlers_cards as hc
+import app
+from bot import subsets as subset_utils
+
+if subset_utils.DATA is None:  # pragma: no cover - ensure dataset available during tests
+    subset_utils.DATA = app.DATA
 
 
 def test_select_matching_countries_identifies_duplicates():
     countries = ["Сингапур", "Люксембург", "Испания", "Германия"]
-    result = hc.select_matching_countries(countries)
+    result = subset_utils.select_matching_countries(countries)
     assert result == {"Сингапур", "Люксембург"}
 
 
 def test_select_countries_by_letter_filters_case_insensitively():
     countries = ["Россия", "Испания", "Сингапур"]
-    result_lower = hc.select_countries_by_letter(countries, "м")
-    result_upper = hc.select_countries_by_letter(countries, "М")
+    result_lower = subset_utils.select_countries_by_letter(countries, "м")
+    result_upper = subset_utils.select_countries_by_letter(countries, "М")
     assert result_lower == {"Россия", "Испания"}
     assert result_upper == result_lower
 
 
 def test_select_countries_by_letter_rejects_invalid_input():
     countries = ["Россия", "Испания"]
-    assert hc.select_countries_by_letter(countries, "1") == set()
-    assert hc.select_countries_by_letter(countries, "москва") == set()
-    assert hc.select_countries_by_letter(countries, "!") == set()
+    assert subset_utils.select_countries_by_letter(countries, "1") == set()
+    assert subset_utils.select_countries_by_letter(countries, "москва") == set()
+    assert subset_utils.select_countries_by_letter(countries, "!") == set()
 
 
 def test_select_remaining_countries_excludes_groups():
     base = {"Сингапур", "Люксембург", "Испания", "Россия", "Германия"}
-    matching = hc.select_matching_countries(base)
-    letter_set = hc.select_countries_by_letter(base, "м")
-    others = hc.select_remaining_countries(base, matching, letter_set)
+    matching = subset_utils.select_matching_countries(base)
+    letter_set = subset_utils.select_countries_by_letter(base, "м")
+    others = subset_utils.select_remaining_countries(base, matching, letter_set)
     assert others == {"Германия"}


### PR DESCRIPTION
## Summary
- introduce shared subset helper module for card and test flows
- add keyboards and callback handling so test mode mirrors card subcategory selection
- register a letter-input handler for test mode and extend unit tests for the new flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68e25b5f61ac832689a29f7f6160519c